### PR TITLE
chore: Fix typo in Surface docs

### DIFF
--- a/packages/website/src/docs/components/core/surface.mdx
+++ b/packages/website/src/docs/components/core/surface.mdx
@@ -1,6 +1,6 @@
 ---
 title: Surface
-description: "Surface is a core elemenet that renders a primary background color."
+description: "Surface is a core component that renders a primary background color."
 type: images
 slug: /components/surface/
 keywords: ["surface", "background"]
@@ -8,7 +8,7 @@ keywords: ["surface", "background"]
 
 # Surface
 
-`Surface` is a core elemenet that renders a primary background color.
+`Surface` is a core component that renders a primary background color.
 
 ## Usage
 


### PR DESCRIPTION
`s/elemenet/component` to match phrasing from the other docs.