### PR TITLE
Styles: Add scale value compiling

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,6 +7,7 @@ module.exports = Object.assign(jestConfig, {
 	collectCoverageFrom: [
 		'<rootDir>/packages/components/src/**/*.{js,jsx}',
 		'<rootDir>/packages/create-styles/src/**/*.{js,jsx}',
+		'<rootDir>/packages/styles/src/**/*.{js,jsx}',
 	],
 	modulePathIgnorePatterns: ['<rootDir>/.remake/'],
 	testPathIgnorePatterns: ['<rootDir>/.remake/'],

--- a/packages/components/jest.config.js
+++ b/packages/components/jest.config.js
@@ -1,0 +1,9 @@
+const { join } = require('path');
+const { projects, ...baseConfig } = require('../../jest.config');
+const pkg = require('./package.json');
+
+module.exports = {
+	...baseConfig,
+	displayName: pkg.name,
+	testMatch: [join(__dirname, 'src/**/*.test.{js,ts,tsx}')],
+};

--- a/packages/components/src/Alert/__tests__/__snapshots__/Alert.test.js.snap
+++ b/packages/components/src/Alert/__tests__/__snapshots__/Alert.test.js.snap
@@ -18,7 +18,7 @@ exports[`props should render as dismissable 1`] = `
       data-g2-component="Flex"
     >
       <div
-        class="wp-components-flex-item wp-components-flex-block css-rl20b"
+        class="wp-components-flex-item wp-components-flex-block css-16celyg"
         data-g2-c16t="true"
         data-g2-component="FlexBlock"
       >
@@ -122,7 +122,7 @@ exports[`props should render correctly 1`] = `
       data-g2-component="Flex"
     >
       <div
-        class="wp-components-flex-item wp-components-flex-block css-rl20b"
+        class="wp-components-flex-item wp-components-flex-block css-16celyg"
         data-g2-c16t="true"
         data-g2-component="FlexBlock"
       >
@@ -167,7 +167,7 @@ exports[`props should render with status 1`] = `
         data-g2-component="Flex"
       >
         <div
-          class="wp-components-flex-item wp-components-flex-block css-rl20b"
+          class="wp-components-flex-item wp-components-flex-block css-16celyg"
           data-g2-c16t="true"
           data-g2-component="FlexBlock"
         >
@@ -268,7 +268,7 @@ exports[`props should render with status 1`] = `
         data-g2-component="Flex"
       >
         <div
-          class="wp-components-flex-item wp-components-flex-block css-rl20b"
+          class="wp-components-flex-item wp-components-flex-block css-16celyg"
           data-g2-c16t="true"
           data-g2-component="FlexBlock"
         >
@@ -369,7 +369,7 @@ exports[`props should render with status 1`] = `
         data-g2-component="Flex"
       >
         <div
-          class="wp-components-flex-item wp-components-flex-block css-rl20b"
+          class="wp-components-flex-item wp-components-flex-block css-16celyg"
           data-g2-c16t="true"
           data-g2-component="FlexBlock"
         >
@@ -470,7 +470,7 @@ exports[`props should render with status 1`] = `
         data-g2-component="Flex"
       >
         <div
-          class="wp-components-flex-item wp-components-flex-block css-rl20b"
+          class="wp-components-flex-item wp-components-flex-block css-16celyg"
           data-g2-c16t="true"
           data-g2-component="FlexBlock"
         >
@@ -571,7 +571,7 @@ exports[`props should render with status 1`] = `
         data-g2-component="Flex"
       >
         <div
-          class="wp-components-flex-item wp-components-flex-block css-rl20b"
+          class="wp-components-flex-item wp-components-flex-block css-16celyg"
           data-g2-c16t="true"
           data-g2-component="FlexBlock"
         >
@@ -676,7 +676,7 @@ exports[`props should render with title 1`] = `
       data-g2-component="Flex"
     >
       <div
-        class="wp-components-flex-item wp-components-flex-block css-rl20b"
+        class="wp-components-flex-item wp-components-flex-block css-16celyg"
         data-g2-c16t="true"
         data-g2-component="FlexBlock"
       >

--- a/packages/components/src/Button/__tests__/__snapshots__/Button.test.js.snap
+++ b/packages/components/src/Button/__tests__/__snapshots__/Button.test.js.snap
@@ -174,7 +174,7 @@ exports[`props should render hasCaret 1`] = `
     data-g2-component="Flex"
   >
     <span
-      class="wp-components-flex-item wp-components-flex-block css-1rvbqq9"
+      class="wp-components-flex-item wp-components-flex-block css-3bstcb"
       data-g2-c16t="true"
       data-g2-component="ButtonContent"
     >
@@ -233,7 +233,7 @@ exports[`props should render icon 1`] = `
     data-g2-component="Flex"
   >
     <span
-      class="wp-components-flex-item css-1rqfg3c"
+      class="wp-components-flex-item css-1sfr7tf"
       data-g2-c16t="true"
       data-g2-component="ButtonIcon"
     >
@@ -534,7 +534,7 @@ exports[`props should render prefix 1`] = `
     data-g2-component="Flex"
   >
     <span
-      class="wp-components-flex-item css-1rqfg3c"
+      class="wp-components-flex-item css-1sfr7tf"
       data-g2-c16t="true"
       data-g2-component="ButtonPrefix"
     >
@@ -605,7 +605,7 @@ exports[`props should render suffix 1`] = `
     data-g2-component="Flex"
   >
     <span
-      class="wp-components-flex-item wp-components-flex-block css-1rvbqq9"
+      class="wp-components-flex-item wp-components-flex-block css-3bstcb"
       data-g2-c16t="true"
       data-g2-component="ButtonContent"
     >

--- a/packages/components/src/ControlGroup/__tests__/__snapshots__/ControlGroup.test.js.snap
+++ b/packages/components/src/ControlGroup/__tests__/__snapshots__/ControlGroup.test.js.snap
@@ -7,7 +7,7 @@ exports[`props should render correctly 1`] = `
   data-g2-component="ControlGroup"
 >
   <div
-    class="wp-components-flex-item wp-components-control-group-item css-1163fmc"
+    class="wp-components-flex-item wp-components-control-group-item css-wy91s0"
     data-g2-c16t="true"
     data-g2-component="ControlGroupItem"
   >
@@ -84,7 +84,7 @@ exports[`props should render mixed control types 1`] = `
   data-g2-component="ControlGroup"
 >
   <div
-    class="wp-components-flex-item wp-components-control-group-item css-1163fmc"
+    class="wp-components-flex-item wp-components-control-group-item css-wy91s0"
     data-g2-c16t="true"
     data-g2-component="ControlGroupItem"
   >
@@ -94,7 +94,7 @@ exports[`props should render mixed control types 1`] = `
       data-g2-component="SelectWrapper"
     >
       <div
-        class="wp-components-flex-item wp-components-flex-block css-b4041i"
+        class="wp-components-flex-item wp-components-flex-block css-14dt8fo"
         data-g2-c16t="true"
         data-g2-component="FlexBlock"
       >
@@ -142,7 +142,7 @@ exports[`props should render mixed control types 1`] = `
     </div>
   </div>
   <div
-    class="wp-components-flex-item wp-components-control-group-item css-5qryon"
+    class="wp-components-flex-item wp-components-control-group-item css-7if256"
     data-g2-c16t="true"
     data-g2-component="ControlGroupItem"
   >

--- a/packages/components/src/Flex/Flex.js
+++ b/packages/components/src/Flex/Flex.js
@@ -19,7 +19,6 @@ export function Flex({
 	wrap = false,
 	...props
 }) {
-	const gapValue = gap * 4;
 	const direction = useResponsiveValue(directionProp);
 
 	const isColumn = !!direction?.includes('column');
@@ -32,7 +31,7 @@ export function Flex({
 		const _key = child.key || index;
 		const contextProps = {
 			display: isColumn ? 'block' : undefined,
-			gap: gapValue,
+			gap,
 			isColumn,
 			isFirst,
 			isLast,

--- a/packages/components/src/Flex/__tests__/__snapshots__/Flex.test.js.snap
+++ b/packages/components/src/Flex/__tests__/__snapshots__/Flex.test.js.snap
@@ -7,12 +7,12 @@ exports[`props should render + wrap non Flex children 1`] = `
   data-g2-component="Flex"
 >
   <div
-    class="wp-components-flex-item css-1cxb0nc"
+    class="wp-components-flex-item css-x168m"
     data-g2-c16t="true"
     data-g2-component="FlexItem"
   />
   <div
-    class="wp-components-flex-item css-1cxb0nc"
+    class="wp-components-flex-item css-x168m"
     data-g2-c16t="true"
     data-g2-component="FlexItem"
   >
@@ -23,7 +23,7 @@ exports[`props should render + wrap non Flex children 1`] = `
     />
   </div>
   <div
-    class="wp-components-flex-item css-1cxb0nc"
+    class="wp-components-flex-item css-x168m"
     data-g2-c16t="true"
     data-g2-component="FlexItem"
   >
@@ -44,7 +44,7 @@ exports[`props should render align 1`] = `
   data-g2-component="Flex"
 >
   <div
-    class="wp-components-flex-item css-1cxb0nc"
+    class="wp-components-flex-item css-x168m"
     data-g2-c16t="true"
     data-g2-component="FlexItem"
   />
@@ -63,7 +63,7 @@ exports[`props should render correctly 1`] = `
   data-g2-component="Flex"
 >
   <div
-    class="wp-components-flex-item css-1cxb0nc"
+    class="wp-components-flex-item css-x168m"
     data-g2-c16t="true"
     data-g2-component="FlexItem"
   />
@@ -82,7 +82,7 @@ exports[`props should render justify 1`] = `
   data-g2-component="Flex"
 >
   <div
-    class="wp-components-flex-item css-1cxb0nc"
+    class="wp-components-flex-item css-x168m"
     data-g2-c16t="true"
     data-g2-component="FlexItem"
   />
@@ -102,7 +102,7 @@ exports[`props should render spacing 1`] = `
   spacing="5"
 >
   <div
-    class="wp-components-flex-item css-1cxb0nc"
+    class="wp-components-flex-item css-x168m"
     data-g2-c16t="true"
     data-g2-component="FlexItem"
   >

--- a/packages/components/src/FormGroup/__tests__/__snapshots__/FormGroup.test.js.snap
+++ b/packages/components/src/FormGroup/__tests__/__snapshots__/FormGroup.test.js.snap
@@ -7,7 +7,7 @@ exports[`props should render alignLabel 1`] = `
   data-g2-component="FormGroup"
 >
   <div
-    class="wp-components-grid wp-components-form-group css-170dnum"
+    class="wp-components-grid wp-components-form-group css-13x1ydg"
     data-g2-c16t="true"
     data-g2-component="FormGroup"
   >
@@ -55,7 +55,7 @@ exports[`props should render correctly 1`] = `
   data-g2-component="FormGroup"
 >
   <div
-    class="wp-components-grid wp-components-form-group css-170dnum"
+    class="wp-components-grid wp-components-form-group css-13x1ydg"
     data-g2-c16t="true"
     data-g2-component="FormGroup"
   >
@@ -103,7 +103,7 @@ exports[`props should render isMarginless 1`] = `
   data-g2-component="FormGroup"
 >
   <div
-    class="wp-components-grid wp-components-form-group css-170dnum"
+    class="wp-components-grid wp-components-form-group css-13x1ydg"
     data-g2-c16t="true"
     data-g2-component="FormGroup"
   >
@@ -151,7 +151,7 @@ exports[`props should render label without prop correctly 1`] = `
   data-g2-component="FormGroup"
 >
   <div
-    class="wp-components-grid wp-components-form-group css-170dnum"
+    class="wp-components-grid wp-components-form-group css-13x1ydg"
     data-g2-c16t="true"
     data-g2-component="FormGroup"
   >

--- a/packages/components/src/Grid/Grid.js
+++ b/packages/components/src/Grid/Grid.js
@@ -5,7 +5,7 @@ import React from 'react';
 function Grid({
 	align,
 	columns = 2,
-	gap = 12,
+	gap = 3,
 	isInline = false,
 	justify,
 	rows,

--- a/packages/components/src/Grid/__tests__/__snapshots__/Grid.test.js.snap
+++ b/packages/components/src/Grid/__tests__/__snapshots__/Grid.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`props should render align 1`] = `
 <div
-  class="wp-components-grid css-1sz0vlw"
+  class="wp-components-grid css-7cmdl8"
   data-g2-c16t="true"
   data-g2-component="Grid"
 >
@@ -26,7 +26,7 @@ exports[`props should render align 1`] = `
 
 exports[`props should render correctly 1`] = `
 <div
-  class="wp-components-grid css-jj7eeb"
+  class="wp-components-grid css-pegie0"
   data-g2-c16t="true"
   data-g2-component="Grid"
 >
@@ -45,7 +45,7 @@ exports[`props should render correctly 1`] = `
 
 exports[`props should render custom columns 1`] = `
 <div
-  class="wp-components-grid css-1dbbftp"
+  class="wp-components-grid css-uxh12g"
   data-g2-c16t="true"
   data-g2-component="Grid"
 >
@@ -69,7 +69,7 @@ exports[`props should render custom columns 1`] = `
 
 exports[`props should render custom rows 1`] = `
 <div
-  class="wp-components-grid css-ail65s"
+  class="wp-components-grid css-1jyhcgk"
   data-g2-c16t="true"
   data-g2-component="Grid"
 >
@@ -93,7 +93,7 @@ exports[`props should render custom rows 1`] = `
 
 exports[`props should render custom templateColumns 1`] = `
 <div
-  class="wp-components-grid css-qk6req"
+  class="wp-components-grid css-12id820"
   data-g2-c16t="true"
   data-g2-component="Grid"
 >
@@ -117,7 +117,7 @@ exports[`props should render custom templateColumns 1`] = `
 
 exports[`props should render custom templateRows 1`] = `
 <div
-  class="wp-components-grid css-1900w81"
+  class="wp-components-grid css-6bbedq"
   data-g2-c16t="true"
   data-g2-component="Grid"
 >
@@ -141,7 +141,7 @@ exports[`props should render custom templateRows 1`] = `
 
 exports[`props should render gap 1`] = `
 <div
-  class="wp-components-grid css-yn4p4z"
+  class="wp-components-grid css-gxz9wf"
   data-g2-c16t="true"
   data-g2-component="Grid"
 >
@@ -165,7 +165,7 @@ exports[`props should render gap 1`] = `
 
 exports[`props should render isInline 1`] = `
 <div
-  class="wp-components-grid css-1w2ybdf"
+  class="wp-components-grid css-18gwxf5"
   data-g2-c16t="true"
   data-g2-component="Grid"
 >
@@ -189,7 +189,7 @@ exports[`props should render isInline 1`] = `
 
 exports[`props should render justify 1`] = `
 <div
-  class="wp-components-grid css-b3bdpe"
+  class="wp-components-grid css-a7liz6"
   data-g2-c16t="true"
   data-g2-component="Grid"
 >

--- a/packages/components/src/HStack/__tests__/__snapshots__/HStack.test.js.snap
+++ b/packages/components/src/HStack/__tests__/__snapshots__/HStack.test.js.snap
@@ -7,7 +7,7 @@ exports[`props should render Spacer 1`] = `
   data-g2-component="HStack"
 >
   <div
-    class="wp-components-flex-item css-nokw1o"
+    class="wp-components-flex-item css-h0ii8s"
     data-g2-c16t="true"
     data-g2-component="FlexItem"
   >
@@ -18,7 +18,7 @@ exports[`props should render Spacer 1`] = `
     />
   </div>
   <div
-    class="wp-components-flex-item wp-components-flex-block css-rw64f8"
+    class="wp-components-flex-item wp-components-flex-block css-5ntb4p"
     data-g2-c16t="true"
     data-g2-component="Spacer"
   />
@@ -43,7 +43,7 @@ exports[`props should render alignment 1`] = `
   data-g2-component="HStack"
 >
   <div
-    class="wp-components-flex-item css-1cxb0nc"
+    class="wp-components-flex-item css-x168m"
     data-g2-c16t="true"
     data-g2-component="FlexItem"
   >
@@ -74,7 +74,7 @@ exports[`props should render correctly 1`] = `
   data-g2-component="HStack"
 >
   <div
-    class="wp-components-flex-item css-1cxb0nc"
+    class="wp-components-flex-item css-x168m"
     data-g2-c16t="true"
     data-g2-component="FlexItem"
   >
@@ -105,7 +105,7 @@ exports[`props should render spacing 1`] = `
   data-g2-component="HStack"
 >
   <div
-    class="wp-components-flex-item css-nokw1o"
+    class="wp-components-flex-item css-h0ii8s"
     data-g2-c16t="true"
     data-g2-component="FlexItem"
   >

--- a/packages/components/src/Panel/__tests__/__snapshots__/Panel.test.js.snap
+++ b/packages/components/src/Panel/__tests__/__snapshots__/Panel.test.js.snap
@@ -16,7 +16,7 @@ exports[`props should render correctly 1`] = `
     tabindex="0"
   >
     <div
-      class="wp-components-flex-item css-1cxb0nc"
+      class="wp-components-flex-item css-x168m"
       data-g2-c16t="true"
       data-g2-component="FlexItem"
     >
@@ -112,7 +112,7 @@ exports[`props should render seamless 1`] = `
     tabindex="0"
   >
     <div
-      class="wp-components-flex-item css-1cxb0nc"
+      class="wp-components-flex-item css-x168m"
       data-g2-c16t="true"
       data-g2-component="FlexItem"
     >
@@ -207,7 +207,7 @@ exports[`props should render visible 1`] = `
     tabindex="0"
   >
     <div
-      class="wp-components-flex-item css-1cxb0nc"
+      class="wp-components-flex-item css-x168m"
       data-g2-c16t="true"
       data-g2-component="FlexItem"
     >

--- a/packages/components/src/SearchInput/__tests__/__snapshots__/SearchInput.test.js.snap
+++ b/packages/components/src/SearchInput/__tests__/__snapshots__/SearchInput.test.js.snap
@@ -7,7 +7,7 @@ exports[`props should render correctly 1`] = `
   data-g2-component="TextInputWrapper"
 >
   <div
-    class="wp-components-flex-item css-mtk3dw"
+    class="wp-components-flex-item css-1c1od6x"
     data-g2-c16t="true"
     data-g2-component="TextInputPrefix"
   >
@@ -55,7 +55,7 @@ exports[`props should render correctly 1`] = `
     </div>
   </div>
   <div
-    class="wp-components-flex-item wp-components-flex-block css-1ucos74"
+    class="wp-components-flex-item wp-components-flex-block css-1ftyfwb"
     data-g2-c16t="true"
     data-g2-component="TextInputContent"
   >
@@ -151,7 +151,7 @@ exports[`props should render isLoading 1`] = `
   data-g2-component="TextInputWrapper"
 >
   <div
-    class="wp-components-flex-item css-mtk3dw"
+    class="wp-components-flex-item css-1c1od6x"
     data-g2-c16t="true"
     data-g2-component="TextInputPrefix"
   >
@@ -217,7 +217,7 @@ exports[`props should render isLoading 1`] = `
     </div>
   </div>
   <div
-    class="wp-components-flex-item wp-components-flex-block css-1ucos74"
+    class="wp-components-flex-item wp-components-flex-block css-1ftyfwb"
     data-g2-c16t="true"
     data-g2-component="TextInputContent"
   >
@@ -313,7 +313,7 @@ exports[`props should render placeholder 1`] = `
   data-g2-component="TextInputWrapper"
 >
   <div
-    class="wp-components-flex-item css-mtk3dw"
+    class="wp-components-flex-item css-1c1od6x"
     data-g2-c16t="true"
     data-g2-component="TextInputPrefix"
   >
@@ -361,7 +361,7 @@ exports[`props should render placeholder 1`] = `
     </div>
   </div>
   <div
-    class="wp-components-flex-item wp-components-flex-block css-1ucos74"
+    class="wp-components-flex-item wp-components-flex-block css-1ftyfwb"
     data-g2-c16t="true"
     data-g2-component="TextInputContent"
   >
@@ -457,7 +457,7 @@ exports[`props should render prefix 1`] = `
   data-g2-component="TextInputWrapper"
 >
   <div
-    class="wp-components-flex-item css-mtk3dw"
+    class="wp-components-flex-item css-1c1od6x"
     data-g2-c16t="true"
     data-g2-component="TextInputPrefix"
   >
@@ -508,7 +508,7 @@ exports[`props should render prefix 1`] = `
     </span>
   </div>
   <div
-    class="wp-components-flex-item wp-components-flex-block css-1ucos74"
+    class="wp-components-flex-item wp-components-flex-block css-1ftyfwb"
     data-g2-c16t="true"
     data-g2-component="TextInputContent"
   >
@@ -604,7 +604,7 @@ exports[`props should render suffix 1`] = `
   data-g2-component="TextInputWrapper"
 >
   <div
-    class="wp-components-flex-item css-mtk3dw"
+    class="wp-components-flex-item css-1c1od6x"
     data-g2-c16t="true"
     data-g2-component="TextInputPrefix"
   >
@@ -652,7 +652,7 @@ exports[`props should render suffix 1`] = `
     </div>
   </div>
   <div
-    class="wp-components-flex-item wp-components-flex-block css-1ucos74"
+    class="wp-components-flex-item wp-components-flex-block css-1ftyfwb"
     data-g2-c16t="true"
     data-g2-component="TextInputContent"
   >
@@ -751,7 +751,7 @@ exports[`props should render value 1`] = `
   data-g2-component="TextInputWrapper"
 >
   <div
-    class="wp-components-flex-item css-mtk3dw"
+    class="wp-components-flex-item css-1c1od6x"
     data-g2-c16t="true"
     data-g2-component="TextInputPrefix"
   >
@@ -799,7 +799,7 @@ exports[`props should render value 1`] = `
     </div>
   </div>
   <div
-    class="wp-components-flex-item wp-components-flex-block css-1ucos74"
+    class="wp-components-flex-item wp-components-flex-block css-1ftyfwb"
     data-g2-c16t="true"
     data-g2-component="TextInputContent"
   >

--- a/packages/components/src/Select/__tests__/__snapshots__/Select.test.js.snap
+++ b/packages/components/src/Select/__tests__/__snapshots__/Select.test.js.snap
@@ -7,7 +7,7 @@ exports[`props should render children 1`] = `
   data-g2-component="SelectWrapper"
 >
   <div
-    class="wp-components-flex-item wp-components-flex-block css-b4041i"
+    class="wp-components-flex-item wp-components-flex-block css-14dt8fo"
     data-g2-c16t="true"
     data-g2-component="FlexBlock"
   >
@@ -72,7 +72,7 @@ exports[`props should render correctly 1`] = `
   data-g2-component="SelectWrapper"
 >
   <div
-    class="wp-components-flex-item wp-components-flex-block css-b4041i"
+    class="wp-components-flex-item wp-components-flex-block css-14dt8fo"
     data-g2-c16t="true"
     data-g2-component="FlexBlock"
   >
@@ -139,7 +139,7 @@ exports[`props should render disabled 1`] = `
   disabled=""
 >
   <div
-    class="wp-components-flex-item wp-components-flex-block css-b4041i"
+    class="wp-components-flex-item wp-components-flex-block css-14dt8fo"
     data-g2-c16t="true"
     data-g2-component="FlexBlock"
   >
@@ -206,7 +206,7 @@ exports[`props should render readOnly 1`] = `
   data-g2-component="SelectWrapper"
 >
   <div
-    class="wp-components-flex-item wp-components-flex-block css-b4041i"
+    class="wp-components-flex-item wp-components-flex-block css-14dt8fo"
     data-g2-c16t="true"
     data-g2-component="FlexBlock"
   >
@@ -273,7 +273,7 @@ exports[`props should render required 1`] = `
   data-g2-component="SelectWrapper"
 >
   <div
-    class="wp-components-flex-item wp-components-flex-block css-b4041i"
+    class="wp-components-flex-item wp-components-flex-block css-14dt8fo"
     data-g2-c16t="true"
     data-g2-component="FlexBlock"
   >
@@ -340,7 +340,7 @@ exports[`props should render size 1`] = `
   data-g2-component="SelectWrapper"
 >
   <div
-    class="wp-components-flex-item wp-components-flex-block css-b4041i"
+    class="wp-components-flex-item wp-components-flex-block css-14dt8fo"
     data-g2-c16t="true"
     data-g2-component="FlexBlock"
   >

--- a/packages/components/src/Stepper/__tests__/__snapshots__/Stepper.test.js.snap
+++ b/packages/components/src/Stepper/__tests__/__snapshots__/Stepper.test.js.snap
@@ -7,7 +7,7 @@ exports[`props should render correctly 1`] = `
   data-g2-component="Stepper"
 >
   <div
-    class="wp-components-flex-item wp-components-control-group-item css-b4041i"
+    class="wp-components-flex-item wp-components-control-group-item css-14dt8fo"
     data-g2-c16t="true"
     data-g2-component="ControlGroupItem"
   >
@@ -138,7 +138,7 @@ exports[`props should render size 1`] = `
   data-g2-component="Stepper"
 >
   <div
-    class="wp-components-flex-item wp-components-control-group-item css-b4041i"
+    class="wp-components-flex-item wp-components-control-group-item css-14dt8fo"
     data-g2-c16t="true"
     data-g2-component="ControlGroupItem"
   >
@@ -269,7 +269,7 @@ exports[`props should render vertically 1`] = `
   data-g2-component="Stepper"
 >
   <div
-    class="wp-components-flex-item wp-components-control-group-item css-1nln54x"
+    class="wp-components-flex-item wp-components-control-group-item css-1n36a32"
     data-g2-c16t="true"
     data-g2-component="ControlGroupItem"
   >

--- a/packages/components/src/TextInput/__tests__/__snapshots__/TextField.test.js.snap
+++ b/packages/components/src/TextInput/__tests__/__snapshots__/TextField.test.js.snap
@@ -206,7 +206,7 @@ exports[`props should render prefix 1`] = `
   data-g2-component="TextInputWrapper"
 >
   <div
-    class="wp-components-flex-item css-mtk3dw"
+    class="wp-components-flex-item css-1c1od6x"
     data-g2-c16t="true"
     data-g2-component="TextInputPrefix"
   >
@@ -259,7 +259,7 @@ exports[`props should render suffix 1`] = `
   data-g2-component="TextInputWrapper"
 >
   <div
-    class="wp-components-flex-item wp-components-flex-block css-1ucos74"
+    class="wp-components-flex-item wp-components-flex-block css-1ftyfwb"
     data-g2-c16t="true"
     data-g2-component="TextInputContent"
   >

--- a/packages/components/src/VStack/__tests__/__snapshots__/VStack.test.js.snap
+++ b/packages/components/src/VStack/__tests__/__snapshots__/VStack.test.js.snap
@@ -7,7 +7,7 @@ exports[`props should render Spacer 1`] = `
   data-g2-component="VStack"
 >
   <div
-    class="wp-components-flex-item css-j8ij9i"
+    class="wp-components-flex-item css-a6x9qu"
     data-g2-c16t="true"
     data-g2-component="FlexItem"
   >
@@ -18,7 +18,7 @@ exports[`props should render Spacer 1`] = `
     />
   </div>
   <div
-    class="wp-components-flex-item wp-components-flex-block css-1nz71km"
+    class="wp-components-flex-item wp-components-flex-block css-qbeaji"
     data-g2-c16t="true"
     data-g2-component="Spacer"
   />
@@ -43,7 +43,7 @@ exports[`props should render alignment 1`] = `
   data-g2-component="VStack"
 >
   <div
-    class="wp-components-flex-item css-9apqst"
+    class="wp-components-flex-item css-1lhy1y6"
     data-g2-c16t="true"
     data-g2-component="FlexItem"
   >
@@ -74,7 +74,7 @@ exports[`props should render correctly 1`] = `
   data-g2-component="VStack"
 >
   <div
-    class="wp-components-flex-item css-9apqst"
+    class="wp-components-flex-item css-1lhy1y6"
     data-g2-c16t="true"
     data-g2-component="FlexItem"
   >
@@ -105,7 +105,7 @@ exports[`props should render spacing 1`] = `
   data-g2-component="VStack"
 >
   <div
-    class="wp-components-flex-item css-j8ij9i"
+    class="wp-components-flex-item css-a6x9qu"
     data-g2-c16t="true"
     data-g2-component="FlexItem"
   >

--- a/packages/components/src/__fixtures__/components/Sidebar.js
+++ b/packages/components/src/__fixtures__/components/Sidebar.js
@@ -21,7 +21,7 @@ export const Sidebar = ({ children }) => {
 	return (
 		<ComponentsProvider
 			value={{
-				Grid: { gap: 8 },
+				Grid: { gap: 2 },
 				Icon: { size: 16 },
 			}}
 		>

--- a/packages/components/src/__stories__/WIP/GlobalStylesSidebar.stories.js
+++ b/packages/components/src/__stories__/WIP/GlobalStylesSidebar.stories.js
@@ -279,7 +279,7 @@ const Sidebar = ({ children }) => {
 	return (
 		<ComponentsProvider
 			value={{
-				Grid: { gap: 8 },
+				Grid: { gap: 2 },
 				Icon: { size: 16 },
 			}}
 		>

--- a/packages/components/src/__stories__/WIP/UserProfilesPlugin.stories.js
+++ b/packages/components/src/__stories__/WIP/UserProfilesPlugin.stories.js
@@ -42,10 +42,10 @@ const useAppContext = () => useContext(AppContext);
 const componentsProviderValue = {
 	FormGroup: {
 		alignLabel: 'right',
-		gap: 28,
+		gap: 7,
 	},
 	Radio: {
-		gap: 8,
+		gap: 2,
 	},
 };
 

--- a/packages/components/src/__tests__/__snapshots__/Components.test.js.snap
+++ b/packages/components/src/__tests__/__snapshots__/Components.test.js.snap
@@ -19,7 +19,7 @@ exports[`props should render Alert 1`] = `
       data-g2-component="Flex"
     >
       <div
-        class="wp-components-flex-item wp-components-flex-block css-rl20b"
+        class="wp-components-flex-item wp-components-flex-block css-16celyg"
         data-g2-c16t="true"
         data-g2-component="FlexBlock"
       >
@@ -52,7 +52,7 @@ exports[`props should render Alert with css prop 1`] = `
     data-g2-component="Flex"
   >
     <div
-      class="wp-components-flex-item wp-components-flex-block css-rl20b"
+      class="wp-components-flex-item wp-components-flex-block css-16celyg"
       data-g2-c16t="true"
       data-g2-component="FlexBlock"
     >
@@ -84,7 +84,7 @@ exports[`props should render Alert with css prop 2`] = `
     data-g2-component="Flex"
   >
     <div
-      class="wp-components-flex-item wp-components-flex-block css-rl20b"
+      class="wp-components-flex-item wp-components-flex-block css-16celyg"
       data-g2-c16t="true"
       data-g2-component="FlexBlock"
     >
@@ -462,7 +462,7 @@ exports[`props should render Button with css prop 1`] = `
 exports[`props should render Button with css prop 2`] = `
 <button
   aria-busy="false"
-  class="wp-components-button css-fcaezh"
+  class="wp-components-button css-19dy1dy"
   data-destructive="false"
   data-g2-c16t="true"
   data-g2-component="Button"
@@ -736,7 +736,7 @@ exports[`props should render Checkbox with css prop 1`] = `
 exports[`props should render Checkbox with css prop 2`] = `
 <input
   aria-checked="false"
-  class="wp-components-checkbox-element wp-components-checkbox css-1kiuc3l"
+  class="wp-components-checkbox-element wp-components-checkbox css-c5kndp"
   data-g2-c16t="true"
   data-g2-component="Checkbox"
   id="Checkbox"
@@ -873,7 +873,7 @@ exports[`props should render CloseButton with css prop 1`] = `
 exports[`props should render CloseButton with css prop 2`] = `
 <button
   aria-busy="false"
-  class="wp-components-button wp-components-close-button css-vup7rm"
+  class="wp-components-button wp-components-close-button css-19vi5gz"
   data-destructive="false"
   data-g2-c16t="true"
   data-g2-component="CloseButton"
@@ -1015,7 +1015,7 @@ exports[`props should render ControlGroup with css prop 2`] = `
 
 exports[`props should render ControlGroupItem 1`] = `
 <div
-  class="wp-components-flex-item wp-components-control-group-item css-1cmhu4"
+  class="wp-components-flex-item wp-components-control-group-item css-1b8tkeb"
   data-g2-c16t="true"
   data-g2-component="ControlGroupItem"
   id="ControlGroupItem"
@@ -1024,7 +1024,7 @@ exports[`props should render ControlGroupItem 1`] = `
 
 exports[`props should render ControlGroupItem with css prop 1`] = `
 <div
-  class="wp-components-flex-item wp-components-control-group-item css-1cmhu4"
+  class="wp-components-flex-item wp-components-control-group-item css-1b8tkeb"
   data-g2-c16t="true"
   data-g2-component="ControlGroupItem"
   id="ControlGroupItem"
@@ -1033,7 +1033,7 @@ exports[`props should render ControlGroupItem with css prop 1`] = `
 
 exports[`props should render ControlGroupItem with css prop 2`] = `
 <div
-  class="wp-components-flex-item wp-components-control-group-item css-1x31kpe"
+  class="wp-components-flex-item wp-components-control-group-item css-1lb6zlh"
   data-g2-c16t="true"
   data-g2-component="ControlGroupItem"
   id="ControlGroupItem"
@@ -1377,7 +1377,7 @@ exports[`props should render DropdownTrigger with css prop 1`] = `
 exports[`props should render DropdownTrigger with css prop 2`] = `
 <button
   aria-busy="false"
-  class="wp-components-button wp-components-dropdown-trigger css-fcaezh"
+  class="wp-components-button wp-components-dropdown-trigger css-19dy1dy"
   data-destructive="false"
   data-g2-c16t="true"
   data-g2-component="DropdownTrigger"
@@ -1483,7 +1483,7 @@ exports[`props should render Flex with css prop 2`] = `
 
 exports[`props should render FlexBlock 1`] = `
 <div
-  class="wp-components-flex-item wp-components-flex-block css-4z9ate"
+  class="wp-components-flex-item wp-components-flex-block css-fvayjj"
   data-g2-c16t="true"
   data-g2-component="FlexBlock"
   id="FlexBlock"
@@ -1492,7 +1492,7 @@ exports[`props should render FlexBlock 1`] = `
 
 exports[`props should render FlexBlock with css prop 1`] = `
 <div
-  class="wp-components-flex-item wp-components-flex-block css-4z9ate"
+  class="wp-components-flex-item wp-components-flex-block css-fvayjj"
   data-g2-c16t="true"
   data-g2-component="FlexBlock"
   id="FlexBlock"
@@ -1501,7 +1501,7 @@ exports[`props should render FlexBlock with css prop 1`] = `
 
 exports[`props should render FlexBlock with css prop 2`] = `
 <div
-  class="wp-components-flex-item wp-components-flex-block css-11fi7md"
+  class="wp-components-flex-item wp-components-flex-block css-171lkfq"
   data-g2-c16t="true"
   data-g2-component="FlexBlock"
   id="FlexBlock"
@@ -1510,7 +1510,7 @@ exports[`props should render FlexBlock with css prop 2`] = `
 
 exports[`props should render FlexItem 1`] = `
 <div
-  class="wp-components-flex-item css-1suoifq"
+  class="wp-components-flex-item css-invkds"
   data-g2-c16t="true"
   data-g2-component="FlexItem"
   id="FlexItem"
@@ -1519,7 +1519,7 @@ exports[`props should render FlexItem 1`] = `
 
 exports[`props should render FlexItem with css prop 1`] = `
 <div
-  class="wp-components-flex-item css-1suoifq"
+  class="wp-components-flex-item css-invkds"
   data-g2-c16t="true"
   data-g2-component="FlexItem"
   id="FlexItem"
@@ -1528,7 +1528,7 @@ exports[`props should render FlexItem with css prop 1`] = `
 
 exports[`props should render FlexItem with css prop 2`] = `
 <div
-  class="wp-components-flex-item css-141gmrl"
+  class="wp-components-flex-item css-622mbd"
   data-g2-c16t="true"
   data-g2-component="FlexItem"
   id="FlexItem"
@@ -1542,7 +1542,7 @@ exports[`props should render FormGroup 1`] = `
   data-g2-component="FormGroup"
 >
   <div
-    class="wp-components-grid wp-components-form-group css-170dnum"
+    class="wp-components-grid wp-components-form-group css-13x1ydg"
     data-g2-c16t="true"
     data-g2-component="FormGroup"
   />
@@ -1556,7 +1556,7 @@ exports[`props should render FormGroup with css prop 1`] = `
   data-g2-component="FormGroup"
 >
   <div
-    class="wp-components-grid wp-components-form-group css-170dnum"
+    class="wp-components-grid wp-components-form-group css-13x1ydg"
     data-g2-c16t="true"
     data-g2-component="FormGroup"
   />
@@ -1565,7 +1565,7 @@ exports[`props should render FormGroup with css prop 1`] = `
 
 exports[`props should render FormGroup with css prop 2`] = `
 <div
-  class="wp-components-grid wp-components-form-group css-170dnum"
+  class="wp-components-grid wp-components-form-group css-13x1ydg"
   data-g2-c16t="true"
   data-g2-component="FormGroup"
 />
@@ -1573,7 +1573,7 @@ exports[`props should render FormGroup with css prop 2`] = `
 
 exports[`props should render Grid 1`] = `
 <div
-  class="wp-components-grid css-jj7eeb"
+  class="wp-components-grid css-pegie0"
   data-g2-c16t="true"
   data-g2-component="Grid"
   id="Grid"
@@ -1582,7 +1582,7 @@ exports[`props should render Grid 1`] = `
 
 exports[`props should render Grid with css prop 1`] = `
 <div
-  class="wp-components-grid css-jj7eeb"
+  class="wp-components-grid css-pegie0"
   data-g2-c16t="true"
   data-g2-component="Grid"
   id="Grid"
@@ -1591,7 +1591,7 @@ exports[`props should render Grid with css prop 1`] = `
 
 exports[`props should render Grid with css prop 2`] = `
 <div
-  class="wp-components-grid css-1yqvk4u"
+  class="wp-components-grid css-3dwd9k"
   data-g2-c16t="true"
   data-g2-component="Grid"
   id="Grid"
@@ -1963,7 +1963,7 @@ exports[`props should render ModalHeader 1`] = `
   id="ModalHeader"
 >
   <div
-    class="wp-components-flex-item css-1cxb0nc"
+    class="wp-components-flex-item css-x168m"
     data-g2-c16t="true"
     data-g2-component="FlexItem"
   />
@@ -2018,7 +2018,7 @@ exports[`props should render ModalHeader with css prop 1`] = `
   id="ModalHeader"
 >
   <div
-    class="wp-components-flex-item css-1cxb0nc"
+    class="wp-components-flex-item css-x168m"
     data-g2-c16t="true"
     data-g2-component="FlexItem"
   />
@@ -2073,7 +2073,7 @@ exports[`props should render ModalHeader with css prop 2`] = `
   id="ModalHeader"
 >
   <div
-    class="wp-components-flex-item css-1cxb0nc"
+    class="wp-components-flex-item css-x168m"
     data-g2-c16t="true"
     data-g2-component="FlexItem"
   />
@@ -2179,7 +2179,7 @@ exports[`props should render ModalTrigger with css prop 2`] = `
   aria-busy="false"
   aria-expanded="false"
   aria-haspopup="dialog"
-  class="wp-components-button wp-components-modal-trigger css-fcaezh"
+  class="wp-components-button wp-components-modal-trigger css-19dy1dy"
   data-destructive="false"
   data-g2-c16t="true"
   data-g2-component="ModalTrigger"
@@ -2297,7 +2297,7 @@ exports[`props should render Radio with css prop 1`] = `
 exports[`props should render Radio with css prop 2`] = `
 <input
   aria-checked="false"
-  class="wp-components-radio-element wp-components-radio css-1hq07rj"
+  class="wp-components-radio-element wp-components-radio css-1l1yo8r"
   data-g2-c16t="true"
   data-g2-component="Radio"
   id="Radio"
@@ -2382,7 +2382,7 @@ exports[`props should render SearchInput 1`] = `
   data-g2-component="TextInputWrapper"
 >
   <div
-    class="wp-components-flex-item css-mtk3dw"
+    class="wp-components-flex-item css-1c1od6x"
     data-g2-c16t="true"
     data-g2-component="TextInputPrefix"
   >
@@ -2430,7 +2430,7 @@ exports[`props should render SearchInput 1`] = `
     </div>
   </div>
   <div
-    class="wp-components-flex-item wp-components-flex-block css-1ucos74"
+    class="wp-components-flex-item wp-components-flex-block css-1ftyfwb"
     data-g2-c16t="true"
     data-g2-component="TextInputContent"
   >
@@ -2552,7 +2552,7 @@ exports[`props should render Select 1`] = `
   data-g2-component="SelectWrapper"
 >
   <div
-    class="wp-components-flex-item wp-components-flex-block css-b4041i"
+    class="wp-components-flex-item wp-components-flex-block css-14dt8fo"
     data-g2-c16t="true"
     data-g2-component="FlexBlock"
   >
@@ -2902,7 +2902,7 @@ exports[`props should render Stepper 1`] = `
   id="Stepper"
 >
   <div
-    class="wp-components-flex-item wp-components-control-group-item css-b4041i"
+    class="wp-components-flex-item wp-components-control-group-item css-14dt8fo"
     data-g2-c16t="true"
     data-g2-component="ControlGroupItem"
   >
@@ -3034,7 +3034,7 @@ exports[`props should render Stepper with css prop 1`] = `
   id="Stepper"
 >
   <div
-    class="wp-components-flex-item wp-components-control-group-item css-b4041i"
+    class="wp-components-flex-item wp-components-control-group-item css-14dt8fo"
     data-g2-c16t="true"
     data-g2-component="ControlGroupItem"
   >
@@ -3166,7 +3166,7 @@ exports[`props should render Stepper with css prop 2`] = `
   id="Stepper"
 >
   <div
-    class="wp-components-flex-item wp-components-control-group-item css-b4041i"
+    class="wp-components-flex-item wp-components-control-group-item css-14dt8fo"
     data-g2-c16t="true"
     data-g2-component="ControlGroupItem"
   >

--- a/packages/styles/jest.config.js
+++ b/packages/styles/jest.config.js
@@ -1,0 +1,9 @@
+const { join } = require('path');
+const { projects, ...baseConfig } = require('../../jest.config');
+const pkg = require('./package.json');
+
+module.exports = {
+	...baseConfig,
+	displayName: pkg.name,
+	testMatch: [join(__dirname, 'src/**/*.test.{js,ts,tsx}')],
+};

--- a/packages/styles/src/__tests__/css.test.js
+++ b/packages/styles/src/__tests__/css.test.js
@@ -1,0 +1,118 @@
+import { getScaleStyles, responsive } from '../css';
+import { space } from '../mixins/space';
+
+describe('scales', () => {
+	test('should transform space values', () => {
+		const numberValues = {
+			margin: 4,
+			marginTop: 4,
+			marginRight: 4,
+			marginBottom: 4,
+			marginLeft: 4,
+			marginX: 4,
+			marginY: 4,
+			marginBlock: 4,
+			marginBlockEnd: 4,
+			marginBlockStart: 4,
+			marginInline: 4,
+			marginInlineEnd: 4,
+			marginInlineStart: 4,
+			padding: 4,
+			paddingTop: 4,
+			paddingRight: 4,
+			paddingBottom: 4,
+			paddingLeft: 4,
+			paddingX: 4,
+			paddingY: 4,
+			paddingBlock: 4,
+			paddingBlockEnd: 4,
+			paddingBlockStart: 4,
+			paddingInline: 4,
+			paddingInlineEnd: 4,
+			paddingInlineStart: 4,
+			gridGap: 4,
+			gridColumnGap: 4,
+			gridRowGap: 4,
+			gap: 4,
+			columnGap: 4,
+			rowGap: 4,
+		};
+
+		for (const key in numberValues) {
+			const value = numberValues[key];
+			expect(getScaleStyles({ [key]: value })).toEqual({
+				[key]: space(value),
+			});
+		}
+
+		const stringValues = {
+			margin: '6px',
+			marginTop: '6px',
+			marginRight: '6px',
+			marginBottom: '6px',
+			marginLeft: '6px',
+			marginX: '6px',
+			marginY: '6px',
+			marginBlock: '6px',
+			marginBlockEnd: '6px',
+			marginBlockStart: '6px',
+			marginInline: '6px',
+			marginInlineEnd: '6px',
+			marginInlineStart: '6px',
+			padding: '6px',
+			paddingTop: '6px',
+			paddingRight: '6px',
+			paddingBottom: '6px',
+			paddingLeft: '6px',
+			paddingX: '6px',
+			paddingY: '6px',
+			paddingBlock: '6px',
+			paddingBlockEnd: '6px',
+			paddingBlockStart: '6px',
+			paddingInline: '6px',
+			paddingInlineEnd: '6px',
+			paddingInlineStart: '6px',
+			gridGap: '6px',
+			gridColumnGap: '6px',
+			gridRowGap: '6px',
+			gap: '6px',
+			columnGap: '6px',
+			rowGap: '6px',
+		};
+
+		for (const key in stringValues) {
+			const value = stringValues[key];
+			expect(getScaleStyles({ [key]: value })).toEqual({
+				[key]: '6px',
+			});
+		}
+	});
+
+	test('should transform responsive space values', () => {
+		const styles = {
+			marginTop: [5, null, 10],
+		};
+
+		expect(responsive(styles)).toEqual({
+			'@media screen and (min-width: 40em)': {},
+			'@media screen and (min-width: 52em)': {
+				marginTop: space(10),
+			},
+			marginTop: space(5),
+		});
+	});
+
+	test('should transform responsive space string values', () => {
+		const styles = {
+			marginTop: ['5px', null, '10em'],
+		};
+
+		expect(responsive(styles)).toEqual({
+			'@media screen and (min-width: 40em)': {},
+			'@media screen and (min-width: 52em)': {
+				marginTop: '10em',
+			},
+			marginTop: '5px',
+		});
+	});
+});

--- a/packages/styles/src/css.js
+++ b/packages/styles/src/css.js
@@ -1,0 +1,151 @@
+import { is } from '@wp-g2/utils';
+
+import { space } from './mixins/space';
+import { compiler } from './system';
+const { breakpoints, css: compile } = compiler;
+
+// Inspired by:
+// https://github.com/system-ui/theme-ui/blob/master/packages/css/src/index.ts
+
+export const scales = {
+	margin: 'space',
+	marginTop: 'space',
+	marginRight: 'space',
+	marginBottom: 'space',
+	marginLeft: 'space',
+	marginX: 'space',
+	marginY: 'space',
+	marginBlock: 'space',
+	marginBlockEnd: 'space',
+	marginBlockStart: 'space',
+	marginInline: 'space',
+	marginInlineEnd: 'space',
+	marginInlineStart: 'space',
+	padding: 'space',
+	paddingTop: 'space',
+	paddingRight: 'space',
+	paddingBottom: 'space',
+	paddingLeft: 'space',
+	paddingX: 'space',
+	paddingY: 'space',
+	paddingBlock: 'space',
+	paddingBlockEnd: 'space',
+	paddingBlockStart: 'space',
+	paddingInline: 'space',
+	paddingInlineEnd: 'space',
+	paddingInlineStart: 'space',
+	gridGap: 'space',
+	gridColumnGap: 'space',
+	gridRowGap: 'space',
+	gap: 'space',
+	columnGap: 'space',
+	rowGap: 'space',
+};
+
+const transformFns = {
+	space,
+};
+
+/**
+ * Retrieves a scaled values from the Style system based on a style key.
+ *
+ * @param {string} key The style key to scale.
+ * @param {any} value The style value to scale.
+ * @returns {any} The scaled value.
+ */
+export function getScaleValue(key, value) {
+	const scale = scales[key];
+	let next = value;
+
+	if (scale) {
+		const transformFn = transformFns[scale];
+		if (transformFns) {
+			next = transformFn(value);
+		}
+	}
+
+	return next;
+}
+
+/**
+ * Transform a style object with scaled values from the Style system.
+ *
+ * @param {object} styles The style object to transform.
+ * @returns {object} The style object with scaled values.
+ */
+export function getScaleStyles(styles = {}) {
+	const next = {};
+
+	for (const k in styles) {
+		next[k] = getScaleValue(k, styles[k]);
+	}
+
+	return next;
+}
+
+// https://github.com/system-ui/theme-ui/blob/master/packages/css/src/index.ts#L224
+/**
+ * A utility function that generates responsive styles if the value is an array.
+ *
+ * @param {object} styles A styles object
+ * @returns {object} An adjusted styles object with responsive styles (if applicable).
+ */
+export const responsive = (styles = {}) => {
+	const next = {};
+	const mediaQueries = [
+		null,
+		...breakpoints.map((n) => `@media screen and (min-width: ${n})`),
+	];
+
+	for (const k in styles) {
+		const key = k;
+		let value = styles[key];
+
+		if (value === null) continue;
+
+		if (!is.array(value)) {
+			next[key] = value;
+			continue;
+		}
+
+		for (let i = 0; i < value.slice(0, mediaQueries.length).length; i++) {
+			const media = mediaQueries[i];
+			if (!media) {
+				next[key] = getScaleValue(key, value[i]);
+				continue;
+			}
+			next[media] = next[media] || {};
+			if (value[i] === null) continue;
+			next[media][key] = getScaleValue(key, value[i]);
+		}
+	}
+
+	return next;
+};
+
+/**
+ * Enhances the (create-system enhanced) CSS function to account for
+ * scale functions within the Style system.
+ *
+ * @param {any} args The styles to compile.
+ * @returns {string} The compiled styles.
+ */
+export function css(...args) {
+	const [arg, ...rest] = args;
+
+	if (is.plainObject(arg)) {
+		return compile(getScaleStyles(responsive(arg)));
+	}
+
+	if (is.array(arg)) {
+		for (let i = 0, len = arg.length; i < len; i++) {
+			const n = arg[i];
+			if (is.plainObject(n)) {
+				arg[i] = getScaleStyles(responsive(n));
+			}
+		}
+		return compile(...[arg, ...rest]);
+	}
+
+	return compile(...args);
+}

--- a/packages/styles/src/style-system.js
+++ b/packages/styles/src/style-system.js
@@ -1,9 +1,9 @@
 import { compiler } from './system';
+export { css } from './css';
 
 export const {
 	breakpoints,
 	cache,
-	css,
 	cx,
 	flush,
 	getRegisteredStyles,


### PR DESCRIPTION
This update adds scale value handling for the `css` function within the `@wp-g2/styles` package. The implementation is inspired by how Theme UI handles scaled values. However, G2's implementation is more focused, mostly for margin/padding/grid/flex based values.

### Breaking Changes

`Grid`  component implementations of `gap` (e.g. `<Grid gap={28} />`)  will break. Previously, Grid's `gap` used the value directly, without taking into consideration the Style system's grid system. This led to some confusion as components like `<Space />` and `<HStack />` used the grid system for values.

**Before**

```jsx
<Grid gap={28} />
```

**After**

```jsx
<Grid gap={8} />
```

This was observed by @sixhours and @ItsJonQ .