### PR TITLE
Card: Add border-radius design token

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -45,6 +45,7 @@ const ColorInput = ({ value, onChange, fallback = '' }) => {
 const defaultThemeConfig = {
 	colorAdmin: '#3858E9',
 	surfaceColor: '#ffffff',
+	cardBorderRadius: '8px',
 	controlSurfaceColor: null,
 	colorText: null,
 	controlBorderRadius: '4px',
@@ -82,25 +83,27 @@ function Themer({ inspector, setInspector }) {
 	};
 
 	const {
+		cardBorderRadius,
 		colorAdmin,
-		surfaceColor,
-		controlSurfaceColor,
 		colorText,
 		controlBorderRadius,
 		controlHeight,
+		controlSurfaceColor,
 		fontFamily,
 		fontSize,
+		surfaceColor,
 	} = themeConfig;
 
 	const theme = {
+		cardBorderRadius,
 		colorAdmin,
 		colorText,
 		controlBorderRadius,
 		controlHeight,
-		surfaceColor: !isDark ? surfaceColor : null,
 		controlSurfaceColor,
 		fontFamily,
 		fontSize,
+		surfaceColor: !isDark ? surfaceColor : null,
 	};
 
 	return (
@@ -177,6 +180,7 @@ function Themer({ inspector, setInspector }) {
 										<FormGroup label="Border Radius">
 											<TextInput
 												type="number"
+												min={0}
 												value={parseInt(
 													controlBorderRadius,
 													10,
@@ -191,6 +195,7 @@ function Themer({ inspector, setInspector }) {
 										<FormGroup label="Height">
 											<TextInput
 												type="number"
+												min={0}
 												value={parseInt(
 													controlHeight,
 													10,
@@ -215,9 +220,29 @@ function Themer({ inspector, setInspector }) {
 										<FormGroup label="Size">
 											<TextInput
 												type="number"
+												min={0}
 												value={parseInt(fontSize, 10)}
 												onChange={(value) =>
 													update('fontSize')(
+														`${value}px`,
+													)
+												}
+											/>
+										</FormGroup>
+									</Spacer>
+									<Spacer mb={4}>
+										<Subheading>Card</Subheading>
+										<Separator />
+										<FormGroup label="Border Radius">
+											<TextInput
+												type="number"
+												min={0}
+												value={parseInt(
+													cardBorderRadius,
+													10,
+												)}
+												onChange={(value) =>
+													update('cardBorderRadius')(
 														`${value}px`,
 													)
 												}

--- a/packages/components/src/Card/Card.js
+++ b/packages/components/src/Card/Card.js
@@ -1,5 +1,5 @@
 import { connect, ns } from '@wp-g2/context';
-import { cx } from '@wp-g2/styles';
+import { cx, get } from '@wp-g2/styles';
 import React from 'react';
 
 import { Elevation } from '../Elevation';
@@ -14,13 +14,13 @@ function Card({ children, className, elevation = 2, forwardedRef, ...props }) {
 		<Surface {...props} className={classes} ref={forwardedRef}>
 			<View {...ns('CardContent')}>{children}</View>
 			<Elevation
-				css={{ borderRadius: 8 }}
+				css={{ borderRadius: get('cardBorderRadius') }}
 				isInteractive={false}
 				value={elevation ? 1 : 0}
 				{...ns('CardElevation')}
 			/>
 			<Elevation
-				css={{ borderRadius: 8 }}
+				css={{ borderRadius: get('cardBorderRadius') }}
 				isInteractive={false}
 				value={elevation}
 				{...ns('CardElevation')}

--- a/packages/components/src/Card/Card.styles.js
+++ b/packages/components/src/Card/Card.styles.js
@@ -1,7 +1,7 @@
 import { css, get } from '@wp-g2/styles';
 
 export const Card = css`
-	border-radius: 8px;
+	border-radius: ${get('cardBorderRadius')};
 	box-shadow: 0 0 0 1px ${get('surfaceBorderColor')};
 	outline: none;
 `;
@@ -31,13 +31,13 @@ export const headerFooter = css`
 
 export const borderRadius = css`
 	&:first-of-type {
-		border-top-left-radius: 8px;
-		border-top-right-radius: 8px;
+		border-top-left-radius: ${get('cardBorderRadius')};
+		border-top-right-radius: ${get('cardBorderRadius')};
 	}
 
 	&:last-of-type {
-		border-bottom-left-radius: 8px;
-		border-bottom-right-radius: 8px;
+		border-bottom-left-radius: ${get('cardBorderRadius')};
+		border-bottom-right-radius: ${get('cardBorderRadius')};
 	}
 `;
 

--- a/packages/components/src/Card/__tests__/__snapshots__/Card.test.js.snap
+++ b/packages/components/src/Card/__tests__/__snapshots__/Card.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`props should render CardInnerBody 1`] = `
 <div
-  class="wp-components-surface wp-components-card css-1wro4hw"
+  class="wp-components-surface wp-components-card css-azv6f"
   data-g2-c16t="true"
   data-g2-component="Card"
 >
@@ -12,7 +12,7 @@ exports[`props should render CardInnerBody 1`] = `
     data-g2-component="CardContent"
   >
     <div
-      class="wp-components-view wp-components-flex wp-components-card-header css-mrd2oy"
+      class="wp-components-view wp-components-flex wp-components-card-header css-tycr7a"
       data-g2-c16t="true"
       data-g2-component="CardHeader"
       title="Olaf"
@@ -25,7 +25,7 @@ exports[`props should render CardInnerBody 1`] = `
       Some people are worth melting for.
     </div>
     <div
-      class="wp-components-view wp-components-flex wp-components-card-footer css-1exvn52"
+      class="wp-components-view wp-components-flex wp-components-card-footer css-s1cblh"
       data-g2-c16t="true"
       data-g2-component="CardFooter"
     >
@@ -66,12 +66,12 @@ exports[`props should render CardInnerBody 1`] = `
     </div>
   </div>
   <div
-    class="wp-components-elevation css-1y2c0hu"
+    class="wp-components-elevation css-lhxd4v"
     data-g2-c16t="true"
     data-g2-component="CardElevation"
   />
   <div
-    class="wp-components-elevation css-1a0xmxv"
+    class="wp-components-elevation css-g2k0uu"
     data-g2-c16t="true"
     data-g2-component="CardElevation"
   />
@@ -80,7 +80,7 @@ exports[`props should render CardInnerBody 1`] = `
 
 exports[`props should render correctly 1`] = `
 <div
-  class="wp-components-surface wp-components-card css-1wro4hw"
+  class="wp-components-surface wp-components-card css-azv6f"
   data-g2-c16t="true"
   data-g2-component="Card"
 >
@@ -90,13 +90,13 @@ exports[`props should render correctly 1`] = `
     data-g2-component="CardContent"
   >
     <div
-      class="wp-components-view wp-components-flex wp-components-card-header css-mrd2oy"
+      class="wp-components-view wp-components-flex wp-components-card-header css-tycr7a"
       data-g2-c16t="true"
       data-g2-component="CardHeader"
       title="Olaf"
     />
     <div
-      class="wp-components-scrollable wp-components-card-body css-1n4315a"
+      class="wp-components-scrollable wp-components-card-body css-1368q3i"
       data-g2-c16t="true"
       data-g2-component="CardBody"
     >
@@ -107,7 +107,7 @@ exports[`props should render correctly 1`] = `
       </div>
     </div>
     <div
-      class="wp-components-view wp-components-flex wp-components-card-footer css-1exvn52"
+      class="wp-components-view wp-components-flex wp-components-card-footer css-s1cblh"
       data-g2-c16t="true"
       data-g2-component="CardFooter"
     >
@@ -148,12 +148,12 @@ exports[`props should render correctly 1`] = `
     </div>
   </div>
   <div
-    class="wp-components-elevation css-1y2c0hu"
+    class="wp-components-elevation css-lhxd4v"
     data-g2-c16t="true"
     data-g2-component="CardElevation"
   />
   <div
-    class="wp-components-elevation css-1a0xmxv"
+    class="wp-components-elevation css-g2k0uu"
     data-g2-c16t="true"
     data-g2-component="CardElevation"
   />
@@ -162,7 +162,7 @@ exports[`props should render correctly 1`] = `
 
 exports[`props should render elevation 1`] = `
 <div
-  class="wp-components-surface wp-components-card css-1wro4hw"
+  class="wp-components-surface wp-components-card css-azv6f"
   data-g2-c16t="true"
   data-g2-component="Card"
 >
@@ -172,12 +172,12 @@ exports[`props should render elevation 1`] = `
     data-g2-component="CardContent"
   />
   <div
-    class="wp-components-elevation css-1y2c0hu"
+    class="wp-components-elevation css-lhxd4v"
     data-g2-c16t="true"
     data-g2-component="CardElevation"
   />
   <div
-    class="wp-components-elevation css-5pxa7w"
+    class="wp-components-elevation css-19fumss"
     data-g2-c16t="true"
     data-g2-component="CardElevation"
   />
@@ -186,7 +186,7 @@ exports[`props should render elevation 1`] = `
 
 exports[`props should render no elevation 1`] = `
 <div
-  class="wp-components-surface wp-components-card css-1wro4hw"
+  class="wp-components-surface wp-components-card css-azv6f"
   data-g2-c16t="true"
   data-g2-component="Card"
 >
@@ -196,12 +196,12 @@ exports[`props should render no elevation 1`] = `
     data-g2-component="CardContent"
   />
   <div
-    class="wp-components-elevation css-4gtqe5"
+    class="wp-components-elevation css-1505ht1"
     data-g2-c16t="true"
     data-g2-component="CardElevation"
   />
   <div
-    class="wp-components-elevation css-1dzxik3"
+    class="wp-components-elevation css-u1d3br"
     data-g2-c16t="true"
     data-g2-component="CardElevation"
   />

--- a/packages/components/src/__tests__/__snapshots__/Components.test.js.snap
+++ b/packages/components/src/__tests__/__snapshots__/Components.test.js.snap
@@ -485,7 +485,7 @@ exports[`props should render Button with css prop 2`] = `
 
 exports[`props should render Card 1`] = `
 <div
-  class="wp-components-surface wp-components-card css-1wro4hw"
+  class="wp-components-surface wp-components-card css-azv6f"
   data-g2-c16t="true"
   data-g2-component="Card"
   id="Card"
@@ -496,12 +496,12 @@ exports[`props should render Card 1`] = `
     data-g2-component="CardContent"
   />
   <div
-    class="wp-components-elevation css-1y2c0hu"
+    class="wp-components-elevation css-lhxd4v"
     data-g2-c16t="true"
     data-g2-component="CardElevation"
   />
   <div
-    class="wp-components-elevation css-1a0xmxv"
+    class="wp-components-elevation css-g2k0uu"
     data-g2-c16t="true"
     data-g2-component="CardElevation"
   />
@@ -510,7 +510,7 @@ exports[`props should render Card 1`] = `
 
 exports[`props should render Card with css prop 1`] = `
 <div
-  class="wp-components-surface wp-components-card css-1wro4hw"
+  class="wp-components-surface wp-components-card css-azv6f"
   data-g2-c16t="true"
   data-g2-component="Card"
   id="Card"
@@ -521,12 +521,12 @@ exports[`props should render Card with css prop 1`] = `
     data-g2-component="CardContent"
   />
   <div
-    class="wp-components-elevation css-1y2c0hu"
+    class="wp-components-elevation css-lhxd4v"
     data-g2-c16t="true"
     data-g2-component="CardElevation"
   />
   <div
-    class="wp-components-elevation css-1a0xmxv"
+    class="wp-components-elevation css-g2k0uu"
     data-g2-c16t="true"
     data-g2-component="CardElevation"
   />
@@ -535,7 +535,7 @@ exports[`props should render Card with css prop 1`] = `
 
 exports[`props should render Card with css prop 2`] = `
 <div
-  class="wp-components-surface wp-components-card css-1wuasxu"
+  class="wp-components-surface wp-components-card css-zp86it"
   data-g2-c16t="true"
   data-g2-component="Card"
   id="Card"
@@ -546,12 +546,12 @@ exports[`props should render Card with css prop 2`] = `
     data-g2-component="CardContent"
   />
   <div
-    class="wp-components-elevation css-1y2c0hu"
+    class="wp-components-elevation css-lhxd4v"
     data-g2-c16t="true"
     data-g2-component="CardElevation"
   />
   <div
-    class="wp-components-elevation css-1a0xmxv"
+    class="wp-components-elevation css-g2k0uu"
     data-g2-c16t="true"
     data-g2-component="CardElevation"
   />
@@ -560,7 +560,7 @@ exports[`props should render Card with css prop 2`] = `
 
 exports[`props should render CardBody 1`] = `
 <div
-  class="wp-components-scrollable wp-components-card-body css-1n4315a"
+  class="wp-components-scrollable wp-components-card-body css-1368q3i"
   data-g2-c16t="true"
   data-g2-component="CardBody"
   id="CardBody"
@@ -573,7 +573,7 @@ exports[`props should render CardBody 1`] = `
 
 exports[`props should render CardBody with css prop 1`] = `
 <div
-  class="wp-components-scrollable wp-components-card-body css-1n4315a"
+  class="wp-components-scrollable wp-components-card-body css-1368q3i"
   data-g2-c16t="true"
   data-g2-component="CardBody"
   id="CardBody"
@@ -586,7 +586,7 @@ exports[`props should render CardBody with css prop 1`] = `
 
 exports[`props should render CardBody with css prop 2`] = `
 <div
-  class="wp-components-scrollable wp-components-card-body css-94y2zw"
+  class="wp-components-scrollable wp-components-card-body css-tnoq1c"
   data-g2-c16t="true"
   data-g2-component="CardBody"
   id="CardBody"
@@ -599,7 +599,7 @@ exports[`props should render CardBody with css prop 2`] = `
 
 exports[`props should render CardFooter 1`] = `
 <div
-  class="wp-components-view wp-components-flex wp-components-card-footer css-1exvn52"
+  class="wp-components-view wp-components-flex wp-components-card-footer css-s1cblh"
   data-g2-c16t="true"
   data-g2-component="CardFooter"
   id="CardFooter"
@@ -608,7 +608,7 @@ exports[`props should render CardFooter 1`] = `
 
 exports[`props should render CardFooter with css prop 1`] = `
 <div
-  class="wp-components-view wp-components-flex wp-components-card-footer css-1exvn52"
+  class="wp-components-view wp-components-flex wp-components-card-footer css-s1cblh"
   data-g2-c16t="true"
   data-g2-component="CardFooter"
   id="CardFooter"
@@ -617,7 +617,7 @@ exports[`props should render CardFooter with css prop 1`] = `
 
 exports[`props should render CardFooter with css prop 2`] = `
 <div
-  class="wp-components-view wp-components-flex wp-components-card-footer css-f9pali"
+  class="wp-components-view wp-components-flex wp-components-card-footer css-1ahbe4"
   data-g2-c16t="true"
   data-g2-component="CardFooter"
   id="CardFooter"
@@ -626,7 +626,7 @@ exports[`props should render CardFooter with css prop 2`] = `
 
 exports[`props should render CardHeader 1`] = `
 <div
-  class="wp-components-view wp-components-flex wp-components-card-header css-mrd2oy"
+  class="wp-components-view wp-components-flex wp-components-card-header css-tycr7a"
   data-g2-c16t="true"
   data-g2-component="CardHeader"
   id="CardHeader"
@@ -635,7 +635,7 @@ exports[`props should render CardHeader 1`] = `
 
 exports[`props should render CardHeader with css prop 1`] = `
 <div
-  class="wp-components-view wp-components-flex wp-components-card-header css-mrd2oy"
+  class="wp-components-view wp-components-flex wp-components-card-header css-tycr7a"
   data-g2-c16t="true"
   data-g2-component="CardHeader"
   id="CardHeader"
@@ -644,7 +644,7 @@ exports[`props should render CardHeader with css prop 1`] = `
 
 exports[`props should render CardHeader with css prop 2`] = `
 <div
-  class="wp-components-view wp-components-flex wp-components-card-header css-cmcoji"
+  class="wp-components-view wp-components-flex wp-components-card-header css-vll6bw"
   data-g2-c16t="true"
   data-g2-component="CardHeader"
   id="CardHeader"
@@ -1126,7 +1126,7 @@ exports[`props should render DropdownMenu 1`] = `
   id="DropdownMenu"
 >
   <div
-    class="wp-components-surface wp-components-card css-1p33t61"
+    class="wp-components-surface wp-components-card css-bau4y1"
     data-g2-c16t="true"
     data-g2-component="Card"
   >
@@ -1146,12 +1146,12 @@ exports[`props should render DropdownMenu 1`] = `
       </div>
     </div>
     <div
-      class="wp-components-elevation css-1y2c0hu"
+      class="wp-components-elevation css-lhxd4v"
       data-g2-c16t="true"
       data-g2-component="CardElevation"
     />
     <div
-      class="wp-components-elevation css-olcfa"
+      class="wp-components-elevation css-1v5iwrv"
       data-g2-c16t="true"
       data-g2-component="CardElevation"
     />
@@ -1167,7 +1167,7 @@ exports[`props should render DropdownMenu with css prop 1`] = `
   id="DropdownMenu"
 >
   <div
-    class="wp-components-surface wp-components-card css-1p33t61"
+    class="wp-components-surface wp-components-card css-bau4y1"
     data-g2-c16t="true"
     data-g2-component="Card"
   >
@@ -1187,12 +1187,12 @@ exports[`props should render DropdownMenu with css prop 1`] = `
       </div>
     </div>
     <div
-      class="wp-components-elevation css-1y2c0hu"
+      class="wp-components-elevation css-lhxd4v"
       data-g2-c16t="true"
       data-g2-component="CardElevation"
     />
     <div
-      class="wp-components-elevation css-olcfa"
+      class="wp-components-elevation css-1v5iwrv"
       data-g2-c16t="true"
       data-g2-component="CardElevation"
     />
@@ -1208,7 +1208,7 @@ exports[`props should render DropdownMenu with css prop 2`] = `
   id="DropdownMenu"
 >
   <div
-    class="wp-components-surface wp-components-card css-1p33t61"
+    class="wp-components-surface wp-components-card css-bau4y1"
     data-g2-c16t="true"
     data-g2-component="Card"
   >
@@ -1228,12 +1228,12 @@ exports[`props should render DropdownMenu with css prop 2`] = `
       </div>
     </div>
     <div
-      class="wp-components-elevation css-1y2c0hu"
+      class="wp-components-elevation css-lhxd4v"
       data-g2-c16t="true"
       data-g2-component="CardElevation"
     />
     <div
-      class="wp-components-elevation css-olcfa"
+      class="wp-components-elevation css-1v5iwrv"
       data-g2-c16t="true"
       data-g2-component="CardElevation"
     />
@@ -1891,7 +1891,7 @@ exports[`props should render Modal 1`] = `null`;
 
 exports[`props should render ModalBody 1`] = `
 <div
-  class="wp-components-scrollable wp-components-card-body wp-components-modal-body css-1n4315a"
+  class="wp-components-scrollable wp-components-card-body wp-components-modal-body css-1368q3i"
   data-g2-c16t="true"
   data-g2-component="ModalBody"
   id="ModalBody"
@@ -1904,7 +1904,7 @@ exports[`props should render ModalBody 1`] = `
 
 exports[`props should render ModalBody with css prop 1`] = `
 <div
-  class="wp-components-scrollable wp-components-card-body wp-components-modal-body css-1n4315a"
+  class="wp-components-scrollable wp-components-card-body wp-components-modal-body css-1368q3i"
   data-g2-c16t="true"
   data-g2-component="ModalBody"
   id="ModalBody"
@@ -1917,7 +1917,7 @@ exports[`props should render ModalBody with css prop 1`] = `
 
 exports[`props should render ModalBody with css prop 2`] = `
 <div
-  class="wp-components-scrollable wp-components-card-body wp-components-modal-body css-94y2zw"
+  class="wp-components-scrollable wp-components-card-body wp-components-modal-body css-tnoq1c"
   data-g2-c16t="true"
   data-g2-component="ModalBody"
   id="ModalBody"
@@ -1930,7 +1930,7 @@ exports[`props should render ModalBody with css prop 2`] = `
 
 exports[`props should render ModalFooter 1`] = `
 <div
-  class="wp-components-view wp-components-flex wp-components-card-footer wp-components-modal-footer css-1op6tiy"
+  class="wp-components-view wp-components-flex wp-components-card-footer wp-components-modal-footer css-9d2rl5"
   data-g2-c16t="true"
   data-g2-component="ModalFooter"
   id="ModalFooter"
@@ -1939,7 +1939,7 @@ exports[`props should render ModalFooter 1`] = `
 
 exports[`props should render ModalFooter with css prop 1`] = `
 <div
-  class="wp-components-view wp-components-flex wp-components-card-footer wp-components-modal-footer css-1op6tiy"
+  class="wp-components-view wp-components-flex wp-components-card-footer wp-components-modal-footer css-9d2rl5"
   data-g2-c16t="true"
   data-g2-component="ModalFooter"
   id="ModalFooter"
@@ -1948,7 +1948,7 @@ exports[`props should render ModalFooter with css prop 1`] = `
 
 exports[`props should render ModalFooter with css prop 2`] = `
 <div
-  class="wp-components-view wp-components-flex wp-components-card-footer wp-components-modal-footer css-1v0pg8n"
+  class="wp-components-view wp-components-flex wp-components-card-footer wp-components-modal-footer css-1u96hyh"
   data-g2-c16t="true"
   data-g2-component="ModalFooter"
   id="ModalFooter"
@@ -1957,7 +1957,7 @@ exports[`props should render ModalFooter with css prop 2`] = `
 
 exports[`props should render ModalHeader 1`] = `
 <div
-  class="wp-components-view wp-components-flex wp-components-card-header wp-components-modal-header css-1qx4aw0"
+  class="wp-components-view wp-components-flex wp-components-card-header wp-components-modal-header css-1yrbald"
   data-g2-c16t="true"
   data-g2-component="ModalHeader"
   id="ModalHeader"
@@ -2012,7 +2012,7 @@ exports[`props should render ModalHeader 1`] = `
 
 exports[`props should render ModalHeader with css prop 1`] = `
 <div
-  class="wp-components-view wp-components-flex wp-components-card-header wp-components-modal-header css-1qx4aw0"
+  class="wp-components-view wp-components-flex wp-components-card-header wp-components-modal-header css-1yrbald"
   data-g2-c16t="true"
   data-g2-component="ModalHeader"
   id="ModalHeader"
@@ -2067,7 +2067,7 @@ exports[`props should render ModalHeader with css prop 1`] = `
 
 exports[`props should render ModalHeader with css prop 2`] = `
 <div
-  class="wp-components-view wp-components-flex wp-components-card-header wp-components-modal-header css-1h9l55u"
+  class="wp-components-view wp-components-flex wp-components-card-header wp-components-modal-header css-5vfjmn"
   data-g2-c16t="true"
   data-g2-component="ModalHeader"
   id="ModalHeader"

--- a/packages/styles/src/theme/config.js
+++ b/packages/styles/src/theme/config.js
@@ -91,9 +91,14 @@ const CONTROL_PROPS = {
 	controlTextActiveColor: get('colorAdmin'),
 };
 
+const CARD_PROPS = {
+	cardBorderRadius: '8px',
+};
+
 const BASE_THEME = {
 	...G2_COLORS,
 	...COLOR_PROPS,
+	...CARD_PROPS,
 	...CONTROL_PROPS,
 	...FONT_PROPS,
 	...SURFACE_PROPS,


### PR DESCRIPTION
This update adds a design token for `Card` components, specifically `cardBorderRadius`. This allows Card borders to be adjusted via `ThemeProvider` (or CSS variables)