### PR TITLE
Create Styles: ThemeProvider - Inject global on initial render

### DIFF
--- a/packages/create-styles/src/components/ThemeProvider/ThemeProvider.js
+++ b/packages/create-styles/src/components/ThemeProvider/ThemeProvider.js
@@ -12,6 +12,7 @@ import {
 /**
  * @typedef ThemeProviderProps
  * @property {any} children Children to render.
+ * @property {function} injectGlobal Globally injects styles on initial render (provided by an Emotion instance).
  * @property {boolean} isGlobal Determines if the theme styles are rendered globally or scoped locally.
  * @property {boolean} isDark Determines if dark-mode styles should be rendered.
  * @property {boolean} isColorBlind Determines if color-blind-mode styles should be rendered.
@@ -40,6 +41,7 @@ import {
  */
 function ThemeProvider({
 	children,
+	injectGlobal,
 	isGlobal = false,
 	isDark,
 	isColorBlind,
@@ -49,7 +51,7 @@ function ThemeProvider({
 	...props
 }) {
 	const nodeRef = useRef();
-	const themeStyles = useThemeStyles({ isGlobal, theme });
+	const themeStyles = useThemeStyles({ injectGlobal, isGlobal, theme });
 
 	useColorBlindMode({ isColorBlind, isGlobal, ref: nodeRef });
 	useDarkMode({ isDark, isGlobal, ref: nodeRef });

--- a/packages/create-styles/src/components/ThemeProvider/ThemeProvider.utils.js
+++ b/packages/create-styles/src/components/ThemeProvider/ThemeProvider.utils.js
@@ -1,7 +1,10 @@
 import { deepEqual, is } from '@wp-g2/utils';
 import { useEffect, useRef, useState } from 'react';
 
-import { transformValuesToVariables } from '../../createStyleSystem/utils';
+import {
+	transformValuesToVariables,
+	transformValuesToVariablesString,
+} from '../../createStyleSystem/utils';
 import { useReducedMotion } from '../../hooks';
 
 /**
@@ -142,12 +145,29 @@ export function useReducedMotionMode({
  * Hook that sets the Style system's theme.
  * @param {UseThemeStyles} props Props for the hook.
  */
-export function useThemeStyles({ isGlobal = true, theme = {} }) {
+export function useThemeStyles({ injectGlobal, isGlobal = true, theme = {} }) {
 	const [themeStyles, setThemeStyles] = useState({});
+	const didInjectGlobalStyles = useRef(false);
+
 	/**
 	 * Used to track/compare changes for theme prop changes.
 	 */
 	const themeRef = useRef();
+
+	/**
+	 * Work-around to inject a global theme style. This makes it compatible with
+	 * SSR solutions, as injectGlobal is understood by Emotion's SSR flow.
+	 */
+	if (!didInjectGlobalStyles.current && isGlobal && theme) {
+		if (is.function(injectGlobal)) {
+			const globalStyles = transformValuesToVariablesString(
+				':root',
+				theme,
+			);
+			injectGlobal`${globalStyles}`;
+		}
+		didInjectGlobalStyles.current = true;
+	}
 
 	useEffect(() => {
 		/**
@@ -182,7 +202,7 @@ export function useThemeStyles({ isGlobal = true, theme = {} }) {
 			 */
 			setThemeStyles((prev) => ({ ...prev, ...nextTheme }));
 		}
-	}, [isGlobal, theme]);
+	}, [injectGlobal, isGlobal, theme]);
 
 	return themeStyles;
 }

--- a/packages/create-styles/src/components/ThemeProvider/ThemeProvider.utils.js
+++ b/packages/create-styles/src/components/ThemeProvider/ThemeProvider.utils.js
@@ -160,11 +160,15 @@ export function useThemeStyles({ injectGlobal, isGlobal = true, theme = {} }) {
 	 */
 	if (!didInjectGlobalStyles.current && isGlobal && theme) {
 		if (is.function(injectGlobal)) {
-			const globalStyles = transformValuesToVariablesString(
-				':root',
-				theme,
-			);
-			injectGlobal`${globalStyles}`;
+			try {
+				const globalStyles = transformValuesToVariablesString(
+					':root',
+					theme,
+				);
+				injectGlobal`${globalStyles}`;
+			} catch (err) {
+				// eslint-disable-next-line
+			}
 		}
 		didInjectGlobalStyles.current = true;
 	}

--- a/packages/create-styles/src/createStyleSystem/createStyleSystem.js
+++ b/packages/create-styles/src/createStyleSystem/createStyleSystem.js
@@ -1,3 +1,6 @@
+import React from 'react';
+
+import { ThemeProvider as BaseThemeProvider } from '../components/ThemeProvider';
 import { createCompiler } from '../createCompiler';
 import { createCoreElement } from './createCoreElement';
 import { createCoreElements } from './createCoreElements';
@@ -27,6 +30,7 @@ const defaultOptions = DEFAULT_STYLE_SYSTEM_OPTIONS;
  * @property {function} get The primary function to retrieve Style system variables.
  * @property {object} styled A set of styled components.
  * @property {React.Component} View The base <View /> component.
+ * @property {React.Component} ThemeProvider The component (Provider) used to adjust design tokens.
  */
 
 /**
@@ -98,6 +102,13 @@ export function createStyleSystem(options = defaultOptions) {
 
 	const View = core.div;
 
+	/**
+	 * An enhanced (base) ThemeProvider with injectGlobal from the custom Emotion instance.
+	 */
+	const ThemeProvider = (props) => (
+		<BaseThemeProvider {...props} injectGlobal={compiler.injectGlobal} />
+	);
+
 	return {
 		compiler,
 		core,
@@ -107,6 +118,7 @@ export function createStyleSystem(options = defaultOptions) {
 		get,
 		styled,
 		View,
+		ThemeProvider,
 	};
 }
 

--- a/packages/create-styles/src/index.js
+++ b/packages/create-styles/src/index.js
@@ -1,3 +1,2 @@
-export * from './components';
 export * from './createStyleSystem';
 export * from './hooks';

--- a/packages/styles/src/components/ThemeProvider.js
+++ b/packages/styles/src/components/ThemeProvider.js
@@ -1,1 +1,1 @@
-export { ThemeProvider } from '@wp-g2/create-styles';
+export { ThemeProvider } from '../system';

--- a/packages/styles/src/system.js
+++ b/packages/styles/src/system.js
@@ -22,6 +22,7 @@ const systemConfig = {
 };
 
 export const {
+	ThemeProvider,
 	compiler,
 	core,
 	createCoreElement,


### PR DESCRIPTION
This update enhances the `ThemeProvider` from the `create-styles` package to use a custom `ThemeProvider` enhanced with a `injectGlobal` flow from the custom Emotion instance.

This enables `ThemeProvider` to be compatible with Emotion's SSR flow.

Resolves: https://github.com/ItsJonQ/g2/issues/48