### PR TITLE
Context: Add ability to override connected components

### DIFF
--- a/packages/context/src/__tests__/ComponentsProvider.test.js
+++ b/packages/context/src/__tests__/ComponentsProvider.test.js
@@ -96,4 +96,32 @@ describe('props', () => {
 		expect(el).toHaveStyle(`background: white`);
 		expect(el).toHaveStyle(`font-weight: bold`);
 	});
+
+	test('should render _override props', () => {
+		const Olaf = ({ quote, ...props }) => <View {...props}>{quote}</View>;
+		const ConnectedOlaf = connect(Olaf, 'Olaf');
+
+		const contextValue = {
+			Olaf: {
+				_overrides: {
+					quote: 'Warm Hugs!',
+				},
+			},
+		};
+
+		const { container } = render(
+			<>
+				<ComponentsProvider value={contextValue}>
+					<ConnectedOlaf className="olaf" quote="Hello" />
+				</ComponentsProvider>
+			</>,
+		);
+
+		expect(container.firstChild).toMatchSnapshot();
+
+		const el = container.querySelector('.olaf');
+
+		expect(el.innerHTML).toContain('Warm Hugs!');
+		expect(el.innerHTML).not.toContain('Hello');
+	});
 });

--- a/packages/context/src/__tests__/__snapshots__/ComponentsProvider.test.js.snap
+++ b/packages/context/src/__tests__/__snapshots__/ComponentsProvider.test.js.snap
@@ -1,5 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`props should render _override props 1`] = `
+<div
+  data-system-theme-provider="true"
+>
+  <div
+    class="wp-components-olaf olaf css-j1yu9m"
+    data-g2-c16t="true"
+    data-g2-component="Olaf"
+  >
+    Warm Hugs!
+  </div>
+</div>
+`;
+
 exports[`props should render context props 1`] = `
 <div
   data-system-theme-provider="true"

--- a/packages/context/src/connect.js
+++ b/packages/context/src/connect.js
@@ -59,7 +59,11 @@ export function connect(Component, namespace, options = {}) {
 				{};
 		}
 
-		const { css: contextCSS, ...otherContextProps } = contextProps;
+		const {
+			_overrides: overrideProps = {},
+			css: contextCSS,
+			...otherContextProps
+		} = contextProps;
 
 		const initialMergedProps = is.plainObject(contextProps)
 			? { ...otherContextProps, ...props }
@@ -84,6 +88,7 @@ export function connect(Component, namespace, options = {}) {
 				{...cns()}
 				{...ns(displayName)}
 				{...mergedProps}
+				{...overrideProps}
 				className={classes}
 				forwardedRef={forwardedRef}
 			>


### PR DESCRIPTION
This update adds a special prop (`_overrides`) for props being passed to connected components within the Context system. `_overrides` allows for the `ComponentsProvider` to override incoming props from the connected component, similar to the workflow for `!important` in CSS.

**Example**

```jsx
<ComponentsProvider
    value={{
        Text: {
            _overrides: {
                numberOfLines: 2
            }
        }
    }}
/>
```

Resolves: https://github.com/ItsJonQ/g2/issues/31