### PR TITLE
Create Styles: Improve ThemeProvider initial (theme) style rendering

### DIFF
--- a/packages/create-styles/src/components/ThemeProvider/ThemeProvider.js
+++ b/packages/create-styles/src/components/ThemeProvider/ThemeProvider.js
@@ -1,6 +1,7 @@
 import { ThemeProvider as BaseThemeProvider } from 'emotion-theming';
 import React, { useRef } from 'react';
 
+import { useHydrateGlobalStyles } from '../../hooks';
 import {
 	useColorBlindMode,
 	useDarkMode,
@@ -43,6 +44,7 @@ function ThemeProvider({
 	children,
 	injectGlobal,
 	isGlobal = false,
+	globalStyles,
 	isDark,
 	isColorBlind,
 	isReducedMotion,
@@ -50,6 +52,15 @@ function ThemeProvider({
 	theme = {},
 	...props
 }) {
+	/**
+	 * Hydrates global styles (via injectGlobal). This is necessary as there may
+	 * be a chance that <ThemeProvider /> renders before any other (styled)
+	 * component. Injecting global styles early in this manner allows for
+	 * the initial render of theme styles (which also uses injectGlobal)
+	 * to be sequences correctly.
+	 */
+	useHydrateGlobalStyles({ injectGlobal, globalStyles });
+
 	const nodeRef = useRef();
 	const themeStyles = useThemeStyles({ injectGlobal, isGlobal, theme });
 

--- a/packages/create-styles/src/components/ThemeProvider/ThemeProvider.utils.js
+++ b/packages/create-styles/src/components/ThemeProvider/ThemeProvider.utils.js
@@ -157,22 +157,22 @@ export function useThemeStyles({ injectGlobal, isGlobal = true, theme = {} }) {
 	 * Work-around to inject a global theme style. This makes it compatible with
 	 * SSR solutions, as injectGlobal is understood by Emotion's SSR flow.
 	 */
-	// const didInjectGlobalStyles = useRef(false);
+	const didInjectGlobalStyles = useRef(false);
 
-	// if (!didInjectGlobalStyles.current && isGlobal && theme) {
-	// 	if (is.function(injectGlobal)) {
-	// 		try {
-	// 			const globalStyles = transformValuesToVariablesString(
-	// 				':root',
-	// 				theme,
-	// 			);
-	// 			injectGlobal`${globalStyles}`;
-	// 		} catch (err) {
-	// 			// eslint-disable-next-line
-	// 		}
-	// 	}
-	// 	didInjectGlobalStyles.current = true;
-	// }
+	if (!didInjectGlobalStyles.current && isGlobal && theme) {
+		if (is.function(injectGlobal)) {
+			try {
+				const globalStyles = transformValuesToVariablesString(
+					':root',
+					theme,
+				);
+				injectGlobal`${globalStyles}`;
+			} catch (err) {
+				// eslint-disable-next-line
+			}
+		}
+		didInjectGlobalStyles.current = true;
+	}
 
 	useEffect(() => {
 		/**

--- a/packages/create-styles/src/createStyleSystem/createCoreElement.js
+++ b/packages/create-styles/src/createStyleSystem/createCoreElement.js
@@ -2,7 +2,6 @@ import isPropValid from '@emotion/is-prop-valid';
 import { is, mergeRefs } from '@wp-g2/utils';
 import React, { forwardRef } from 'react';
 
-// import { css, cx } from '../compiler';
 import { useHydrateGlobalStyles } from '../hooks';
 import { REDUCED_MOTION_MODE_ATTR } from './constants';
 import { DEFAULT_STYLE_SYSTEM_OPTIONS } from './utils';

--- a/packages/create-styles/src/createStyleSystem/createStyleSystem.js
+++ b/packages/create-styles/src/createStyleSystem/createStyleSystem.js
@@ -106,7 +106,11 @@ export function createStyleSystem(options = defaultOptions) {
 	 * An enhanced (base) ThemeProvider with injectGlobal from the custom Emotion instance.
 	 */
 	const ThemeProvider = (props) => (
-		<BaseThemeProvider {...props} injectGlobal={compiler.injectGlobal} />
+		<BaseThemeProvider
+			{...props}
+			globalStyles={globalStyles}
+			injectGlobal={compiler.injectGlobal}
+		/>
 	);
 
 	const styleSystem = {

--- a/packages/create-styles/src/hooks/useHydrateGlobalStyles.js
+++ b/packages/create-styles/src/hooks/useHydrateGlobalStyles.js
@@ -40,10 +40,10 @@ export function useHydrateGlobalStyles({ injectGlobal, globalStyles = {} }) {
 			${highContrastModeCSSVariables};
 			${darkHighContrastModeCSSVariables};
 		`;
-	}
 
-	/**
-	 * Ensure that this only happens once with a singleton state.
-	 */
-	__INTERNAL_STATE__.didInjectGlobal = true;
+		/**
+		 * Ensure that this only happens once with a singleton state.
+		 */
+		__INTERNAL_STATE__.didInjectGlobal = true;
+	}
 }


### PR DESCRIPTION
This update improves the ThemeProvider initial (theme) style rendering. The
change needed to achieve this involved coordinating the injectGlobal function
call in the ThemeProvider generated from the createStyleSystem factory.

The initial injectGlobal is the same as a coreElement, using the
useHydrateGlobalStyles hook.

Ultimately, this helps with SSR rendering for custom theme styles.