### PR TITLE
Add dark and high contrast theme support to ThemeProvider

### DIFF
--- a/.storybook/themes/blueberry.js
+++ b/.storybook/themes/blueberry.js
@@ -1,6 +1,6 @@
 import { createTheme } from '@wp-g2/styles';
 
-const theme = createTheme(({ get, space, ...theme }) => {
+const theme = createTheme(({ get, space, theme }) => {
 	const COLOR_PROPS = {
 		colorAdmin: '#3858E9',
 		colorText: '#3a3b3c',

--- a/packages/create-styles/src/components/ThemeProvider/ThemeProvider.js
+++ b/packages/create-styles/src/components/ThemeProvider/ThemeProvider.js
@@ -1,5 +1,12 @@
+import { repeat } from '@wp-g2/utils';
 import React, { useRef } from 'react';
 
+import {
+	DARK_HIGH_CONTRAST_MODE_MODE_ATTR,
+	DARK_MODE_ATTR,
+	HIGH_CONTRAST_MODE_MODE_ATTR,
+	MODE_SPECIFICITY_COMPOUND_LEVEL,
+} from '../../createStyleSystem/constants';
 import { useHydrateGlobalStyles } from '../../hooks';
 import {
 	useColorBlindMode,
@@ -49,6 +56,9 @@ function ThemeProvider({
 	isReducedMotion,
 	isHighContrast,
 	theme = {},
+	darkTheme = {},
+	highContrastTheme = {},
+	darkHighContrastTheme = {},
 	...props
 }) {
 	/**
@@ -56,12 +66,38 @@ function ThemeProvider({
 	 * be a chance that <ThemeProvider /> renders before any other (styled)
 	 * component. Injecting global styles early in this manner allows for
 	 * the initial render of theme styles (which also uses injectGlobal)
-	 * to be sequences correctly.
+	 * to be sequenced correctly.
 	 */
 	useHydrateGlobalStyles({ injectGlobal, globalStyles });
 
 	const nodeRef = useRef();
-	const themeStyles = useThemeStyles({ injectGlobal, isGlobal, theme });
+	const themeStyles = {
+		...useThemeStyles({ injectGlobal, isGlobal, theme, selector: ':root' }),
+		...useThemeStyles({
+			injectGlobal,
+			isGlobal,
+			theme: darkTheme,
+			selector: repeat(DARK_MODE_ATTR, MODE_SPECIFICITY_COMPOUND_LEVEL),
+		}),
+		...useThemeStyles({
+			injectGlobal,
+			isGlobal,
+			theme: highContrastTheme,
+			selector: repeat(
+				HIGH_CONTRAST_MODE_MODE_ATTR,
+				MODE_SPECIFICITY_COMPOUND_LEVEL,
+			),
+		}),
+		...useThemeStyles({
+			injectGlobal,
+			isGlobal,
+			theme: darkHighContrastTheme,
+			selector: repeat(
+				DARK_HIGH_CONTRAST_MODE_MODE_ATTR,
+				MODE_SPECIFICITY_COMPOUND_LEVEL,
+			),
+		}),
+	};
 
 	useColorBlindMode({ isColorBlind, isGlobal, ref: nodeRef });
 	useDarkMode({ isDark, isGlobal, ref: nodeRef });

--- a/packages/create-styles/src/components/ThemeProvider/ThemeProvider.utils.js
+++ b/packages/create-styles/src/components/ThemeProvider/ThemeProvider.utils.js
@@ -136,15 +136,19 @@ export function useReducedMotionMode({
 	}, [isGlobal, isReducedMotion, ref]);
 }
 
-function createThemeStore(initialTheme = {}) {
+function createThemeStore(initialTheme = '') {
 	return createStore((set) => ({
 		theme: initialTheme,
 		setTheme: (next) => {
 			set((prev) => {
-				return { theme: { ...prev.theme, ...next } };
+				return { theme: next };
 			});
 		},
 	}));
+}
+
+export function useThemeStylesStore() {
+	return useRef(createThemeStore());
 }
 
 /**
@@ -163,8 +167,8 @@ export function useThemeStyles({
 	theme = {},
 	selector = ':root',
 }) {
-	const store = useRef(createThemeStore()).current;
-	const { setTheme: setThemeStyles, theme: themeStyles } = store();
+	const store = useThemeStylesStore();
+	const { setTheme: setThemeStyles, theme: themeStyles } = store.current();
 
 	/**
 	 * Used to track/compare changes for theme prop changes.
@@ -183,6 +187,7 @@ export function useThemeStyles({
 				const globalStyles = transformValuesToVariablesString(
 					selector,
 					theme,
+					isGlobal,
 				);
 				injectGlobal`${globalStyles}`;
 			} catch (err) {
@@ -206,8 +211,11 @@ export function useThemeStyles({
 		 * the Style system understands and can be retrieved using the get() function.
 		 */
 		const styleNode = getStyleNode();
-		const nextTheme = transformValuesToVariables(theme);
-		const nextThemeHtml = transformValuesToVariablesString(':root', theme);
+		const nextThemeHtml = transformValuesToVariablesString(
+			selector,
+			theme,
+			isGlobal,
+		);
 
 		if (isGlobal) {
 			/**
@@ -222,7 +230,7 @@ export function useThemeStyles({
 			 * Otherwise, we can set it to the themeStyles state, which will be
 			 * rendered as custom properties on the ThemeProvider (HTMLDivElement).
 			 */
-			setThemeStyles(nextTheme);
+			setThemeStyles(nextThemeHtml);
 		}
 	}, [injectGlobal, isGlobal, setThemeStyles, theme]);
 

--- a/packages/create-styles/src/components/ThemeProvider/ThemeProvider.utils.js
+++ b/packages/create-styles/src/components/ThemeProvider/ThemeProvider.utils.js
@@ -157,7 +157,12 @@ function createThemeStore(initialTheme = {}) {
  * Hook that sets the Style system's theme.
  * @param {UseThemeStyles} props Props for the hook.
  */
-export function useThemeStyles({ injectGlobal, isGlobal = true, theme = {} }) {
+export function useThemeStyles({
+	injectGlobal,
+	isGlobal = true,
+	theme = {},
+	selector = ':root',
+}) {
 	const store = useRef(createThemeStore()).current;
 	const { setTheme: setThemeStyles, theme: themeStyles } = store();
 
@@ -176,7 +181,7 @@ export function useThemeStyles({ injectGlobal, isGlobal = true, theme = {} }) {
 		if (is.function(injectGlobal)) {
 			try {
 				const globalStyles = transformValuesToVariablesString(
-					':root',
+					selector,
 					theme,
 				);
 				injectGlobal`${globalStyles}`;

--- a/packages/create-styles/src/createStyleSystem/createStyleSystem.js
+++ b/packages/create-styles/src/createStyleSystem/createStyleSystem.js
@@ -109,8 +109,8 @@ export function createStyleSystem(options = defaultOptions) {
 	const ThemeProvider = (props) => (
 		<BaseThemeProvider
 			{...props}
+			compiler={compiler}
 			globalStyles={globalStyles}
-			injectGlobal={compiler.injectGlobal}
 		/>
 	);
 

--- a/packages/create-styles/src/createStyleSystem/utils.js
+++ b/packages/create-styles/src/createStyleSystem/utils.js
@@ -84,9 +84,22 @@ export function transformValuesToVariables(values = {}) {
 export function transformValuesToVariablesString(
 	selector = ':root',
 	values = {},
+	isGlobal = true,
 ) {
 	const variables = transformValuesToVariables(values);
-	const next = [`${selector} {`];
+
+	const next = [];
+	let needsTerminator = false;
+
+	if (isGlobal) {
+		next.push(`${selector} {`);
+		needsTerminator = true;
+	} else {
+		if (selector !== ':root') {
+			next.push(`&${selector} {`);
+			needsTerminator = true;
+		}
+	}
 
 	for (const [key, value] of Object.entries(variables)) {
 		const ref = value;
@@ -95,7 +108,9 @@ export function transformValuesToVariablesString(
 		}
 	}
 
-	next.push('}');
+	if (needsTerminator) {
+		next.push('}');
+	}
 
 	return next.join('');
 }


### PR DESCRIPTION
### Testing instructions

Checkout the branch locally and pass `darkTheme`, `highContrastTheme` and `darkHighContrastTheme` to the `ThemeProvider` in `.storybook/preview.js`. Pass some different variables and ensure they're being applied correctly with the expected specificity.