### PR TITLE
Add controlled modal example

### DIFF
--- a/packages/components/src/BaseModal/BaseModal.js
+++ b/packages/components/src/BaseModal/BaseModal.js
@@ -13,10 +13,10 @@ function BaseModal(props, forwardedRef) {
 		backdropTransitionDuration = 250,
 		children,
 		className,
-		dialog: dialogProp,
 		label = 'Modal',
 		/* Deprecate in favour of `trigger`*/
 		renderTrigger = null,
+		state,
 		transitionTimingFunction = 'ease-in-out',
 		trigger = null,
 		visible = false,
@@ -25,7 +25,7 @@ function BaseModal(props, forwardedRef) {
 	} = useContextSystem(props, 'BaseModal');
 
 	const _dialog = useDialogState({ animated: true, visible });
-	const dialog = dialogProp || _dialog;
+	const dialog = state || _dialog;
 
 	const { isUnderLayer } = useModalState(dialog);
 

--- a/packages/components/src/Modal/__stories__/Modal.stories.js
+++ b/packages/components/src/Modal/__stories__/Modal.stories.js
@@ -8,6 +8,7 @@ import {
 	ModalHeader,
 	ModalTrigger,
 	useModalContext,
+	useModalState,
 } from '../index';
 
 export default {
@@ -50,5 +51,21 @@ export const _default = () => {
 				</Modal>
 			</ModalBody>
 		</Modal>
+	);
+};
+
+export const Controlled = () => {
+	const dialog = useModalState();
+
+	return (
+		<>
+			<Button onClick={dialog.toggle}>Secondary toggle</Button>
+			<Modal state={dialog} trigger={<ModalTrigger>Open</ModalTrigger>}>
+				<ModalHeader title={'Modal Title'} />
+				<ModalBody>
+					<h2>Controlled Modal</h2>
+				</ModalBody>
+			</Modal>
+		</>
 	);
 };

--- a/packages/components/src/Modal/index.js
+++ b/packages/components/src/Modal/index.js
@@ -5,3 +5,4 @@ export { default as ModalHeader } from './ModalHeader';
 export { default as ModalTitle } from './ModalTitle';
 export { default as ModalTrigger } from './ModalTrigger';
 export * from './Modal.Context';
+export { useModalState } from './useModalState';

--- a/packages/components/src/Modal/useModalState.js
+++ b/packages/components/src/Modal/useModalState.js
@@ -1,0 +1,4 @@
+import { useDialogState } from '@wp-g2/a11y';
+
+export const useModalState = (args) =>
+	useDialogState({ ...args, animated: true });


### PR DESCRIPTION
### Testing instructions

Run storybook and visit the controlled modal example and ensure both buttons cause the modal to open and that focus is returned to them. Likewise, open the default modal example and ensure it still behaves as expected.

Closes https://github.com/ItsJonQ/g2/issues/29