### PR TITLE
UnitInput: Improve cssProp validation to allow for values like calc()

### DIFF
--- a/packages/components/src/UnitInput/index.d.ts
+++ b/packages/components/src/UnitInput/index.d.ts
@@ -1,0 +1,1 @@
+export * from '../../types/components/UnitInput';

--- a/packages/utils/src/unitValues.js
+++ b/packages/utils/src/unitValues.js
@@ -24,13 +24,15 @@ export const isValidCSSValueForProp = (prop, value) => {
 
 	if (is.undefined(computedStyleMap[prop])) return true;
 
-	// Reset
+	// 1. Reset current style value.
 	computedStyleMap[prop] = '';
-
+	// 2. Cache current style value for validation (may not be an empty string).
+	const current = computedStyleMap[prop];
+	// 3. Apply next value.
 	const next = getCSSValue(value);
 	computedStyleMap[prop] = next;
-
-	return computedStyleMap[prop].includes(value);
+	// 4. Check to see if next value was correctly applied.
+	return current !== computedStyleMap[prop];
 };
 
 export const isValidNumericUnitValue = (value) => {


### PR DESCRIPTION
<img width="816" alt="Screen Shot 2020-11-04 at 4 34 54 PM" src="https://user-images.githubusercontent.com/2322354/98170856-c30c9a00-1ebc-11eb-85b7-7916dcc0dc49.png">

This update improves the CSS prop validation util function that's used in `UnitInput`. This fix allows for values like `calc()`, `var()`, and other native CSS functions.

### 🕹 Testing

* Run `yarn start` to fire up Storybook
* Go to the [UnitInput story](http://localhost:6006/iframe.html?id=components-unitinput--default)
* Add whatever (valid) `calc()` value to one of the inputs. Example `calc(1px + 2px)`

Resolves: https://github.com/ItsJonQ/g2/issues/76