### PR TITLE
Controls: Add inline rendering support within Text

### DIFF
--- a/packages/components/src/Alert/__tests__/__snapshots__/Alert.test.js.snap
+++ b/packages/components/src/Alert/__tests__/__snapshots__/Alert.test.js.snap
@@ -613,7 +613,7 @@ exports[`props should render with title 1`] = `
           data-g2-component="Spacer"
         >
           <div
-            class="components-truncate wp-components-truncate components-text wp-components-text components-heading wp-components-heading css-p1xqfd"
+            class="components-truncate wp-components-truncate components-text wp-components-text components-heading wp-components-heading css-1gn0pau"
             data-g2-c16t="true"
             data-g2-component="Heading"
           >

--- a/packages/components/src/Animated/__tests__/__snapshots__/Animated.test.js.snap
+++ b/packages/components/src/Animated/__tests__/__snapshots__/Animated.test.js.snap
@@ -17,7 +17,7 @@ exports[`props should render as another HTML tag 1`] = `
   data-g2-component="Animated"
 >
   <span
-    class="components-truncate wp-components-truncate components-text wp-components-text css-1j5v64k"
+    class="components-truncate wp-components-truncate components-text wp-components-text css-fd3l03"
     data-g2-c16t="true"
     data-g2-component="Text"
   >

--- a/packages/components/src/Avatar/__tests__/__snapshots__/Avatar.test.js.snap
+++ b/packages/components/src/Avatar/__tests__/__snapshots__/Avatar.test.js.snap
@@ -10,7 +10,7 @@ exports[`props should render correctly 1`] = `
     class="css-qze8kw"
   >
     <div
-      class="components-truncate wp-components-truncate components-text wp-components-text components-initials wp-components-initials css-8o2ae8"
+      class="components-truncate wp-components-truncate components-text wp-components-text components-initials wp-components-initials css-19d3w4a"
       data-g2-c16t="true"
       data-g2-component="AvatarInitials"
     >
@@ -30,7 +30,7 @@ exports[`props should render with a border 1`] = `
     class="css-qze8kw"
   >
     <div
-      class="components-truncate wp-components-truncate components-text wp-components-text components-initials wp-components-initials css-8o2ae8"
+      class="components-truncate wp-components-truncate components-text wp-components-text components-initials wp-components-initials css-19d3w4a"
       data-g2-c16t="true"
       data-g2-component="AvatarInitials"
     >
@@ -67,7 +67,7 @@ exports[`props should render with a custom color 1`] = `
     class="css-qze8kw"
   >
     <div
-      class="components-truncate wp-components-truncate components-text wp-components-text components-initials wp-components-initials css-32gu8g"
+      class="components-truncate wp-components-truncate components-text wp-components-text components-initials wp-components-initials css-ac848o"
       data-g2-c16t="true"
       data-g2-component="AvatarInitials"
     >
@@ -104,7 +104,7 @@ exports[`props should render with a custom size 1`] = `
     class="css-qze8kw"
   >
     <div
-      class="components-truncate wp-components-truncate components-text wp-components-text components-initials wp-components-initials css-1j3613t"
+      class="components-truncate wp-components-truncate components-text wp-components-text components-initials wp-components-initials css-g9xxgu"
       data-g2-c16t="true"
       data-g2-component="AvatarInitials"
     >
@@ -124,7 +124,7 @@ exports[`props should render with a custom small size + square 1`] = `
     class="css-qze8kw"
   >
     <div
-      class="components-truncate wp-components-truncate components-text wp-components-text components-initials wp-components-initials css-1g8a9bf"
+      class="components-truncate wp-components-truncate components-text wp-components-text components-initials wp-components-initials css-u91ryw"
       data-g2-c16t="true"
       data-g2-component="AvatarInitials"
     >
@@ -144,7 +144,7 @@ exports[`props should render with a custom xSmall size + square 1`] = `
     class="css-qze8kw"
   >
     <div
-      class="components-truncate wp-components-truncate components-text wp-components-text components-initials wp-components-initials css-19qhcq0"
+      class="components-truncate wp-components-truncate components-text wp-components-text components-initials wp-components-initials css-rxi5fo"
       data-g2-c16t="true"
       data-g2-component="AvatarInitials"
     >
@@ -164,7 +164,7 @@ exports[`props should render with an alternate shape 1`] = `
     class="css-qze8kw"
   >
     <div
-      class="components-truncate wp-components-truncate components-text wp-components-text components-initials wp-components-initials css-32gu8g"
+      class="components-truncate wp-components-truncate components-text wp-components-text components-initials wp-components-initials css-ac848o"
       data-g2-c16t="true"
       data-g2-component="AvatarInitials"
     >
@@ -201,7 +201,7 @@ exports[`props should render with an alternate size 1`] = `
     class="css-qze8kw"
   >
     <div
-      class="components-truncate wp-components-truncate components-text wp-components-text components-initials wp-components-initials css-1j3613t"
+      class="components-truncate wp-components-truncate components-text wp-components-text components-initials wp-components-initials css-g9xxgu"
       data-g2-c16t="true"
       data-g2-component="AvatarInitials"
     >
@@ -221,7 +221,7 @@ exports[`props should render with animateOnImageLoad disabled 1`] = `
     class="css-qze8kw"
   >
     <div
-      class="components-truncate wp-components-truncate components-text wp-components-text components-initials wp-components-initials css-8o2ae8"
+      class="components-truncate wp-components-truncate components-text wp-components-text components-initials wp-components-initials css-19d3w4a"
       data-g2-c16t="true"
       data-g2-component="AvatarInitials"
     >
@@ -258,7 +258,7 @@ exports[`props should render with image src 1`] = `
     class="css-qze8kw"
   >
     <div
-      class="components-truncate wp-components-truncate components-text wp-components-text components-initials wp-components-initials css-8o2ae8"
+      class="components-truncate wp-components-truncate components-text wp-components-text components-initials wp-components-initials css-19d3w4a"
       data-g2-c16t="true"
       data-g2-component="AvatarInitials"
     >

--- a/packages/components/src/Badge/__tests__/__snapshots__/Badge.test.js.snap
+++ b/packages/components/src/Badge/__tests__/__snapshots__/Badge.test.js.snap
@@ -7,7 +7,7 @@ exports[`props should render color 1`] = `
   data-g2-component="Badge"
 >
   <span
-    class="components-truncate wp-components-truncate components-text wp-components-text css-qnyxla"
+    class="components-truncate wp-components-truncate components-text wp-components-text css-1djx5to"
     data-g2-c16t="true"
     data-g2-component="Text"
   >
@@ -23,7 +23,7 @@ exports[`props should render correctly 1`] = `
   data-g2-component="Badge"
 >
   <span
-    class="components-truncate wp-components-truncate components-text wp-components-text css-qnyxla"
+    class="components-truncate wp-components-truncate components-text wp-components-text css-1djx5to"
     data-g2-c16t="true"
     data-g2-component="Text"
   >
@@ -39,7 +39,7 @@ exports[`props should render display 1`] = `
   data-g2-component="Badge"
 >
   <span
-    class="components-truncate wp-components-truncate components-text wp-components-text css-qnyxla"
+    class="components-truncate wp-components-truncate components-text wp-components-text css-1djx5to"
     data-g2-c16t="true"
     data-g2-component="Text"
   >
@@ -55,7 +55,7 @@ exports[`props should render isBold 1`] = `
   data-g2-component="Badge"
 >
   <span
-    class="components-truncate wp-components-truncate components-text wp-components-text css-qnyxla"
+    class="components-truncate wp-components-truncate components-text wp-components-text css-1djx5to"
     data-g2-c16t="true"
     data-g2-component="Text"
   >
@@ -71,7 +71,7 @@ exports[`props should render isRounded 1`] = `
   data-g2-component="Badge"
 >
   <span
-    class="components-truncate wp-components-truncate components-text wp-components-text css-qnyxla"
+    class="components-truncate wp-components-truncate components-text wp-components-text css-1djx5to"
     data-g2-c16t="true"
     data-g2-component="Text"
   >
@@ -87,7 +87,7 @@ exports[`props should render truncate 1`] = `
   data-g2-component="Badge"
 >
   <span
-    class="components-truncate wp-components-truncate components-text wp-components-text css-qnyxla"
+    class="components-truncate wp-components-truncate components-text wp-components-text css-1djx5to"
     data-g2-c16t="true"
     data-g2-component="Text"
   >

--- a/packages/components/src/BaseField/BaseField.styles.js
+++ b/packages/components/src/BaseField/BaseField.styles.js
@@ -81,3 +81,13 @@ export const errorFocus = css`
 		border-color: ${ui.get('controlDestructiveBorderColorFocus')};
 	}
 `;
+
+export const inline = css`
+	display: inline-flex;
+	vertical-align: baseline;
+	width: auto;
+
+	${ui.browsers.safari(`
+			vertical-align: middle;
+	`)}
+`;

--- a/packages/components/src/BaseField/useBaseField.js
+++ b/packages/components/src/BaseField/useBaseField.js
@@ -12,6 +12,7 @@ export function useBaseField(props) {
 		error = false,
 		isClickable = false,
 		isFocused = false,
+		isInline = false,
 		isSubtle = false,
 		...otherProps
 	} = useContextSystem(props, 'BaseField');
@@ -28,12 +29,14 @@ export function useBaseField(props) {
 				isSubtle && styles.subtle,
 				error && styles.error,
 				error && isFocused && styles.errorFocus,
+				isInline && styles.inline,
 				className,
 			),
 		[
 			className,
 			controlGroupStyles,
 			error,
+			isInline,
 			isClickable,
 			isFocused,
 			isSubtle,

--- a/packages/components/src/BlankSlate/__tests__/__snapshots__/BlankSlate.test.js.snap
+++ b/packages/components/src/BlankSlate/__tests__/__snapshots__/BlankSlate.test.js.snap
@@ -28,7 +28,7 @@ exports[`props should render correctly 1`] = `
         data-g2-component="VStack"
       >
         <div
-          class="components-truncate wp-components-truncate components-text wp-components-text components-heading wp-components-heading css-1tp3mjk"
+          class="components-truncate wp-components-truncate components-text wp-components-text components-heading wp-components-heading css-7vv3ms"
           data-g2-c16t="true"
           data-g2-component="Heading"
         >
@@ -66,7 +66,7 @@ exports[`props should render correctly 1`] = `
           Twitter Embed
         </div>
         <span
-          class="components-truncate wp-components-truncate components-text wp-components-text css-1j5v64k"
+          class="components-truncate wp-components-truncate components-text wp-components-text css-fd3l03"
           data-g2-c16t="true"
           data-g2-component="Text"
         >
@@ -119,7 +119,7 @@ exports[`props should render correctly without description and icon 1`] = `
         data-g2-component="VStack"
       >
         <div
-          class="components-truncate wp-components-truncate components-text wp-components-text components-heading wp-components-heading css-1tp3mjk"
+          class="components-truncate wp-components-truncate components-text wp-components-text components-heading wp-components-heading css-7vv3ms"
           data-g2-c16t="true"
           data-g2-component="Heading"
         >

--- a/packages/components/src/ControlGroup/__tests__/__snapshots__/ControlGroup.test.js.snap
+++ b/packages/components/src/ControlGroup/__tests__/__snapshots__/ControlGroup.test.js.snap
@@ -97,7 +97,7 @@ exports[`props should render mixed control types 1`] = `
         data-g2-component="FlexItem"
       >
         <span
-          class="components-truncate wp-components-truncate components-text wp-components-text css-1fdlgmt"
+          class="components-truncate wp-components-truncate components-text wp-components-text css-duu1p5"
           data-g2-c16t="true"
           data-g2-component="Text"
         >

--- a/packages/components/src/ControlLabel/__tests__/__snapshots__/ControlLabel.test.js.snap
+++ b/packages/components/src/ControlLabel/__tests__/__snapshots__/ControlLabel.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`props should render correctly 1`] = `
 <label
-  class="components-truncate wp-components-truncate components-text wp-components-text components-control-label wp-components-control-label css-1ppuusk"
+  class="components-truncate wp-components-truncate components-text wp-components-text components-control-label wp-components-control-label css-1kug32t"
   data-g2-c16t="true"
   data-g2-component="ControlLabel"
 >
@@ -12,7 +12,7 @@ exports[`props should render correctly 1`] = `
 
 exports[`props should render htmlFor 1`] = `
 <label
-  class="components-truncate wp-components-truncate components-text wp-components-text components-control-label wp-components-control-label css-1ppuusk"
+  class="components-truncate wp-components-truncate components-text wp-components-text components-control-label wp-components-control-label css-1kug32t"
   data-g2-c16t="true"
   data-g2-component="ControlLabel"
   for="Field"
@@ -23,7 +23,7 @@ exports[`props should render htmlFor 1`] = `
 
 exports[`props should render no truncate 1`] = `
 <label
-  class="components-truncate wp-components-truncate components-text wp-components-text components-control-label wp-components-control-label css-1538vg2"
+  class="components-truncate wp-components-truncate components-text wp-components-text components-control-label wp-components-control-label css-1clb0kw"
   data-g2-c16t="true"
   data-g2-component="ControlLabel"
 >
@@ -33,7 +33,7 @@ exports[`props should render no truncate 1`] = `
 
 exports[`props should render size 1`] = `
 <label
-  class="components-truncate wp-components-truncate components-text wp-components-text components-control-label wp-components-control-label css-176x1s9"
+  class="components-truncate wp-components-truncate components-text wp-components-text components-control-label wp-components-control-label css-1gsin9e"
   data-g2-c16t="true"
   data-g2-component="ControlLabel"
 >

--- a/packages/components/src/FormGroup/__tests__/__snapshots__/FormGroup.test.js.snap
+++ b/packages/components/src/FormGroup/__tests__/__snapshots__/FormGroup.test.js.snap
@@ -7,7 +7,7 @@ exports[`props should render alignLabel 1`] = `
   data-g2-component="FormGroup"
 >
   <label
-    class="components-truncate wp-components-truncate components-text wp-components-text components-control-label wp-components-control-label css-y9y9ic"
+    class="components-truncate wp-components-truncate components-text wp-components-text components-control-label wp-components-control-label css-tlx71c"
     data-g2-c16t="true"
     data-g2-component="ControlLabel"
     for="fname"
@@ -40,7 +40,7 @@ exports[`props should render correctly 1`] = `
   data-g2-component="FormGroup"
 >
   <label
-    class="components-truncate wp-components-truncate components-text wp-components-text components-control-label wp-components-control-label css-116wlbg"
+    class="components-truncate wp-components-truncate components-text wp-components-text components-control-label wp-components-control-label css-337b03"
     data-g2-c16t="true"
     data-g2-component="ControlLabel"
     for="fname"
@@ -73,7 +73,7 @@ exports[`props should render label without prop correctly 1`] = `
   data-g2-component="FormGroup"
 >
   <label
-    class="components-truncate wp-components-truncate components-text wp-components-text components-control-label wp-components-control-label css-1ppuusk"
+    class="components-truncate wp-components-truncate components-text wp-components-text components-control-label wp-components-control-label css-1kug32t"
     data-g2-c16t="true"
     data-g2-component="ControlLabel"
     for="fname"
@@ -104,7 +104,7 @@ exports[`props should render vertically 1`] = `
   data-g2-component="FormGroup"
 >
   <label
-    class="components-truncate wp-components-truncate components-text wp-components-text components-control-label wp-components-control-label css-116wlbg"
+    class="components-truncate wp-components-truncate components-text wp-components-text components-control-label wp-components-control-label css-337b03"
     data-g2-c16t="true"
     data-g2-component="ControlLabel"
     for="fname"

--- a/packages/components/src/Heading/__tests__/__snapshots__/Heading.test.js.snap
+++ b/packages/components/src/Heading/__tests__/__snapshots__/Heading.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`props should render as another element 1`] = `
 <h3
-  class="components-truncate wp-components-truncate components-text wp-components-text components-heading wp-components-heading css-ypbzir"
+  class="components-truncate wp-components-truncate components-text wp-components-text components-heading wp-components-heading css-1eywi6"
   data-g2-c16t="true"
   data-g2-component="Heading"
 >
@@ -12,7 +12,7 @@ exports[`props should render as another element 1`] = `
 
 exports[`props should render correctly 1`] = `
 <div
-  class="components-truncate wp-components-truncate components-text wp-components-text components-heading wp-components-heading css-ohvggs"
+  class="components-truncate wp-components-truncate components-text wp-components-text components-heading wp-components-heading css-3uc59p"
   data-g2-c16t="true"
   data-g2-component="Heading"
 >
@@ -22,7 +22,7 @@ exports[`props should render correctly 1`] = `
 
 exports[`props should render size 1`] = `
 <div
-  class="components-truncate wp-components-truncate components-text wp-components-text components-heading wp-components-heading css-ypbzir"
+  class="components-truncate wp-components-truncate components-text wp-components-text components-heading wp-components-heading css-1eywi6"
   data-g2-c16t="true"
   data-g2-component="Heading"
 >

--- a/packages/components/src/Initials/__tests__/__snapshots__/Initials.test.js.snap
+++ b/packages/components/src/Initials/__tests__/__snapshots__/Initials.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`props should render correctly 1`] = `
 <span
-  class="components-truncate wp-components-truncate components-text wp-components-text components-initials wp-components-initials css-1xgp14x"
+  class="components-truncate wp-components-truncate components-text wp-components-text components-initials wp-components-initials css-5jp2hk"
   data-g2-c16t="true"
   data-g2-component="Initials"
 >

--- a/packages/components/src/Link/__tests__/__snapshots__/Link.test.js.snap
+++ b/packages/components/src/Link/__tests__/__snapshots__/Link.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`props should render correctly 1`] = `
 <a
-  class="components-truncate wp-components-truncate components-text wp-components-text components-link wp-components-link css-zvxhcg"
+  class="components-truncate wp-components-truncate components-text wp-components-text components-link wp-components-link css-yf2kff"
   data-g2-c16t="true"
   data-g2-component="Link"
   href="#"
@@ -13,7 +13,7 @@ exports[`props should render correctly 1`] = `
 
 exports[`props should render isPlain 1`] = `
 <a
-  class="components-truncate wp-components-truncate components-text wp-components-text components-link wp-components-link css-5dahqk"
+  class="components-truncate wp-components-truncate components-text wp-components-text components-link wp-components-link css-qipf4h"
   data-g2-c16t="true"
   data-g2-component="Link"
   href="#"

--- a/packages/components/src/Lozenge/__tests__/__snapshots__/Lozenge.test.js.snap
+++ b/packages/components/src/Lozenge/__tests__/__snapshots__/Lozenge.test.js.snap
@@ -7,7 +7,7 @@ exports[`props should render correctly 1`] = `
   data-g2-component="Badge"
 >
   <span
-    class="components-truncate wp-components-truncate components-text wp-components-text css-qnyxla"
+    class="components-truncate wp-components-truncate components-text wp-components-text css-1djx5to"
     data-g2-c16t="true"
     data-g2-component="Text"
   >

--- a/packages/components/src/SearchInput/__tests__/__snapshots__/SearchInput.test.js.snap
+++ b/packages/components/src/SearchInput/__tests__/__snapshots__/SearchInput.test.js.snap
@@ -10,7 +10,7 @@ exports[`props should render correctly 1`] = `
     class="css-tn92r9"
   >
     <span
-      class="components-truncate wp-components-truncate components-text wp-components-text css-1j5v64k"
+      class="components-truncate wp-components-truncate components-text wp-components-text css-fd3l03"
       data-g2-c16t="true"
       data-g2-component="Text"
     >
@@ -268,7 +268,7 @@ exports[`props should render placeholder 1`] = `
     class="css-tn92r9"
   >
     <span
-      class="components-truncate wp-components-truncate components-text wp-components-text css-1j5v64k"
+      class="components-truncate wp-components-truncate components-text wp-components-text css-fd3l03"
       data-g2-c16t="true"
       data-g2-component="Text"
     >
@@ -388,7 +388,7 @@ exports[`props should render prefix 1`] = `
     class="css-tn92r9"
   >
     <span
-      class="components-truncate wp-components-truncate components-text wp-components-text css-1j5v64k"
+      class="components-truncate wp-components-truncate components-text wp-components-text css-fd3l03"
       data-g2-c16t="true"
       data-g2-component="Text"
     >
@@ -511,7 +511,7 @@ exports[`props should render suffix 1`] = `
     class="css-tn92r9"
   >
     <span
-      class="components-truncate wp-components-truncate components-text wp-components-text css-1j5v64k"
+      class="components-truncate wp-components-truncate components-text wp-components-text css-fd3l03"
       data-g2-c16t="true"
       data-g2-component="Text"
     >
@@ -634,7 +634,7 @@ exports[`props should render value 1`] = `
     class="css-tn92r9"
   >
     <span
-      class="components-truncate wp-components-truncate components-text wp-components-text css-1j5v64k"
+      class="components-truncate wp-components-truncate components-text wp-components-text css-fd3l03"
       data-g2-c16t="true"
       data-g2-component="Text"
     >

--- a/packages/components/src/Select/Select.js
+++ b/packages/components/src/Select/Select.js
@@ -23,6 +23,7 @@ function Select(props, forwardedRef) {
 		disabled,
 		error = false,
 		id: idProp,
+		isInline = false,
 		isFocused: isFocusedProp = false,
 		isSubtle,
 		onBlur = noop,
@@ -48,6 +49,7 @@ function Select(props, forwardedRef) {
 		gap: 0,
 		isClickable: true,
 		isFocused,
+		isInline,
 		isSubtle,
 	});
 

--- a/packages/components/src/Select/__tests__/__snapshots__/Select.test.js.snap
+++ b/packages/components/src/Select/__tests__/__snapshots__/Select.test.js.snap
@@ -28,7 +28,7 @@ exports[`props should render children 1`] = `
     data-g2-component="FlexItem"
   >
     <span
-      class="components-truncate wp-components-truncate components-text wp-components-text css-1fdlgmt"
+      class="components-truncate wp-components-truncate components-text wp-components-text css-duu1p5"
       data-g2-c16t="true"
       data-g2-component="Text"
     >
@@ -88,7 +88,7 @@ exports[`props should render correctly 1`] = `
     data-g2-component="FlexItem"
   >
     <span
-      class="components-truncate wp-components-truncate components-text wp-components-text css-1fdlgmt"
+      class="components-truncate wp-components-truncate components-text wp-components-text css-duu1p5"
       data-g2-c16t="true"
       data-g2-component="Text"
     >
@@ -150,7 +150,7 @@ exports[`props should render disabled 1`] = `
     data-g2-component="FlexItem"
   >
     <span
-      class="components-truncate wp-components-truncate components-text wp-components-text css-1fdlgmt"
+      class="components-truncate wp-components-truncate components-text wp-components-text css-duu1p5"
       data-g2-c16t="true"
       data-g2-component="Text"
     >
@@ -211,7 +211,7 @@ exports[`props should render readOnly 1`] = `
     data-g2-component="FlexItem"
   >
     <span
-      class="components-truncate wp-components-truncate components-text wp-components-text css-1fdlgmt"
+      class="components-truncate wp-components-truncate components-text wp-components-text css-duu1p5"
       data-g2-c16t="true"
       data-g2-component="Text"
     >
@@ -272,7 +272,7 @@ exports[`props should render required 1`] = `
     data-g2-component="FlexItem"
   >
     <span
-      class="components-truncate wp-components-truncate components-text wp-components-text css-1fdlgmt"
+      class="components-truncate wp-components-truncate components-text wp-components-text css-duu1p5"
       data-g2-c16t="true"
       data-g2-component="Text"
     >
@@ -332,7 +332,7 @@ exports[`props should render size 1`] = `
     data-g2-component="FlexItem"
   >
     <span
-      class="components-truncate wp-components-truncate components-text wp-components-text css-1fdlgmt"
+      class="components-truncate wp-components-truncate components-text wp-components-text css-duu1p5"
       data-g2-c16t="true"
       data-g2-component="Text"
     >

--- a/packages/components/src/Subheading/__tests__/__snapshots__/Subheading.test.js.snap
+++ b/packages/components/src/Subheading/__tests__/__snapshots__/Subheading.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`props should render correctly 1`] = `
 <div
-  class="components-truncate wp-components-truncate components-text wp-components-text components-subheading wp-components-subheading css-epbge3"
+  class="components-truncate wp-components-truncate components-text wp-components-text components-subheading wp-components-subheading css-8r4buc"
   data-g2-c16t="true"
   data-g2-component="Subheading"
 >

--- a/packages/components/src/Tag/__tests__/__snapshots__/Tag.test.js.snap
+++ b/packages/components/src/Tag/__tests__/__snapshots__/Tag.test.js.snap
@@ -7,7 +7,7 @@ exports[`props should render color 1`] = `
   data-g2-component="Tag"
 >
   <span
-    class="components-truncate wp-components-truncate components-text wp-components-text css-1ejcfnr"
+    class="components-truncate wp-components-truncate components-text wp-components-text css-spr0sd"
     data-g2-c16t="true"
     data-g2-component="Text"
   >
@@ -23,7 +23,7 @@ exports[`props should render correctly 1`] = `
   data-g2-component="Tag"
 >
   <span
-    class="components-truncate wp-components-truncate components-text wp-components-text css-1ejcfnr"
+    class="components-truncate wp-components-truncate components-text wp-components-text css-spr0sd"
     data-g2-c16t="true"
     data-g2-component="Text"
   >
@@ -39,7 +39,7 @@ exports[`props should render display 1`] = `
   data-g2-component="Tag"
 >
   <span
-    class="components-truncate wp-components-truncate components-text wp-components-text css-1ejcfnr"
+    class="components-truncate wp-components-truncate components-text wp-components-text css-spr0sd"
     data-g2-c16t="true"
     data-g2-component="Text"
   >
@@ -56,7 +56,7 @@ exports[`props should render href 1`] = `
   href="#"
 >
   <span
-    class="components-truncate wp-components-truncate components-text wp-components-text css-1ejcfnr"
+    class="components-truncate wp-components-truncate components-text wp-components-text css-spr0sd"
     data-g2-c16t="true"
     data-g2-component="Text"
   >
@@ -72,7 +72,7 @@ exports[`props should render onRemove 1`] = `
   data-g2-component="Tag"
 >
   <span
-    class="components-truncate wp-components-truncate components-text wp-components-text css-1ejcfnr"
+    class="components-truncate wp-components-truncate components-text wp-components-text css-spr0sd"
     data-g2-c16t="true"
     data-g2-component="Text"
   >
@@ -88,7 +88,7 @@ exports[`props should render removeButtonText 1`] = `
   data-g2-component="Tag"
 >
   <span
-    class="components-truncate wp-components-truncate components-text wp-components-text css-1ejcfnr"
+    class="components-truncate wp-components-truncate components-text wp-components-text css-spr0sd"
     data-g2-c16t="true"
     data-g2-component="Text"
   >

--- a/packages/components/src/Text/Text.styles.js
+++ b/packages/components/src/Text/Text.styles.js
@@ -2,6 +2,7 @@ import { css, ui } from '@wp-g2/styles';
 
 export const Text = css`
 	color: ${ui.color.text};
+	line-height: ${ui.get('fontLineHeightBase')};
 `;
 
 export const block = css`

--- a/packages/components/src/Text/__tests__/__snapshots__/Text.test.js.snap
+++ b/packages/components/src/Text/__tests__/__snapshots__/Text.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`props should render align 1`] = `
 <span
-  class="components-truncate wp-components-truncate components-text wp-components-text css-1wxp07y"
+  class="components-truncate wp-components-truncate components-text wp-components-text css-lkjn5s"
   data-g2-c16t="true"
   data-g2-component="Text"
 >
@@ -12,7 +12,7 @@ exports[`props should render align 1`] = `
 
 exports[`props should render as another element 1`] = `
 <div
-  class="components-truncate wp-components-truncate components-text wp-components-text css-1j5v64k"
+  class="components-truncate wp-components-truncate components-text wp-components-text css-fd3l03"
   data-g2-c16t="true"
   data-g2-component="Text"
 >
@@ -22,7 +22,7 @@ exports[`props should render as another element 1`] = `
 
 exports[`props should render color 1`] = `
 <span
-  class="components-truncate wp-components-truncate components-text wp-components-text css-11b9cfw"
+  class="components-truncate wp-components-truncate components-text wp-components-text css-6lujs1"
   data-g2-c16t="true"
   data-g2-component="Text"
 >
@@ -32,7 +32,7 @@ exports[`props should render color 1`] = `
 
 exports[`props should render correctly 1`] = `
 <span
-  class="components-truncate wp-components-truncate components-text wp-components-text css-1j5v64k"
+  class="components-truncate wp-components-truncate components-text wp-components-text css-fd3l03"
   data-g2-c16t="true"
   data-g2-component="Text"
 >
@@ -42,7 +42,7 @@ exports[`props should render correctly 1`] = `
 
 exports[`props should render custom size 1`] = `
 <span
-  class="components-truncate wp-components-truncate components-text wp-components-text css-14o6hkn"
+  class="components-truncate wp-components-truncate components-text wp-components-text css-kgfxlh"
   data-g2-c16t="true"
   data-g2-component="Text"
 >
@@ -52,7 +52,7 @@ exports[`props should render custom size 1`] = `
 
 exports[`props should render display 1`] = `
 <span
-  class="components-truncate wp-components-truncate components-text wp-components-text css-104o95s"
+  class="components-truncate wp-components-truncate components-text wp-components-text css-181g4vn"
   data-g2-c16t="true"
   data-g2-component="Text"
 >
@@ -62,7 +62,7 @@ exports[`props should render display 1`] = `
 
 exports[`props should render highlighted words 1`] = `
 <span
-  class="components-truncate wp-components-truncate components-text wp-components-text css-hr4v4k"
+  class="components-truncate wp-components-truncate components-text wp-components-text css-1vx235c"
   data-g2-c16t="true"
   data-g2-component="Text"
 >
@@ -89,7 +89,7 @@ exports[`props should render highlighted words 1`] = `
 
 exports[`props should render highlighted words with highlightCaseSensitive 1`] = `
 <span
-  class="components-truncate wp-components-truncate components-text wp-components-text css-hr4v4k"
+  class="components-truncate wp-components-truncate components-text wp-components-text css-1vx235c"
   data-g2-c16t="true"
   data-g2-component="Text"
 >
@@ -104,7 +104,7 @@ exports[`props should render highlighted words with highlightCaseSensitive 1`] =
 
 exports[`props should render highlighted words with undefined passed 1`] = `
 <span
-  class="components-truncate wp-components-truncate components-text wp-components-text css-1j5v64k"
+  class="components-truncate wp-components-truncate components-text wp-components-text css-fd3l03"
   data-g2-c16t="true"
   data-g2-component="Text"
 >
@@ -114,7 +114,7 @@ exports[`props should render highlighted words with undefined passed 1`] = `
 
 exports[`props should render isBlock 1`] = `
 <span
-  class="components-truncate wp-components-truncate components-text wp-components-text css-1jk3501"
+  class="components-truncate wp-components-truncate components-text wp-components-text css-3u9ej"
   data-g2-c16t="true"
   data-g2-component="Text"
 >
@@ -124,7 +124,7 @@ exports[`props should render isBlock 1`] = `
 
 exports[`props should render lineHeight 1`] = `
 <span
-  class="components-truncate wp-components-truncate components-text wp-components-text css-u1l4v"
+  class="components-truncate wp-components-truncate components-text wp-components-text css-p8ndxg"
   data-g2-c16t="true"
   data-g2-component="Text"
 >
@@ -134,7 +134,7 @@ exports[`props should render lineHeight 1`] = `
 
 exports[`props should render optimizeReadabilityFor 1`] = `
 <span
-  class="components-truncate wp-components-truncate components-text wp-components-text css-28rm95"
+  class="components-truncate wp-components-truncate components-text wp-components-text css-hp28c3"
   data-g2-c16t="true"
   data-g2-component="Text"
 >
@@ -144,7 +144,7 @@ exports[`props should render optimizeReadabilityFor 1`] = `
 
 exports[`props should render size 1`] = `
 <span
-  class="components-truncate wp-components-truncate components-text wp-components-text css-nrydup"
+  class="components-truncate wp-components-truncate components-text wp-components-text css-1lm7oza"
   data-g2-c16t="true"
   data-g2-component="Text"
 >
@@ -154,7 +154,7 @@ exports[`props should render size 1`] = `
 
 exports[`props should render truncate 1`] = `
 <span
-  class="components-truncate wp-components-truncate components-text wp-components-text css-18w9o67"
+  class="components-truncate wp-components-truncate components-text wp-components-text css-1g5c1k2"
   data-g2-c16t="true"
   data-g2-component="Text"
 >
@@ -164,7 +164,7 @@ exports[`props should render truncate 1`] = `
 
 exports[`props should render upperCase 1`] = `
 <span
-  class="components-truncate wp-components-truncate components-text wp-components-text css-1qmbsxf"
+  class="components-truncate wp-components-truncate components-text wp-components-text css-eb2hg3"
   data-g2-c16t="true"
   data-g2-component="Text"
 >
@@ -174,7 +174,7 @@ exports[`props should render upperCase 1`] = `
 
 exports[`props should render variant 1`] = `
 <span
-  class="components-truncate wp-components-truncate components-text wp-components-text css-lzynkp"
+  class="components-truncate wp-components-truncate components-text wp-components-text css-1u3my9s"
   data-g2-c16t="true"
   data-g2-component="Text"
 >
@@ -184,7 +184,7 @@ exports[`props should render variant 1`] = `
 
 exports[`props should render weight 1`] = `
 <span
-  class="components-truncate wp-components-truncate components-text wp-components-text css-9bfe36"
+  class="components-truncate wp-components-truncate components-text wp-components-text css-1qyg1ku"
   data-g2-c16t="true"
   data-g2-component="Text"
 >

--- a/packages/components/src/Text/useText.js
+++ b/packages/components/src/Text/useText.js
@@ -1,5 +1,5 @@
 import { hasNamespace, useContextSystem } from '@wp-g2/context';
-import { css, cx, get, getFontSize } from '@wp-g2/styles';
+import { css, cx, getFontSize, ui } from '@wp-g2/styles';
 import { getOptimalTextShade, is } from '@wp-g2/utils';
 import React, { useMemo } from 'react';
 
@@ -9,6 +9,7 @@ import { createHighlighterText } from './Text.utils';
 
 export function useText(props) {
 	const {
+		adjustLineHeightForInnerControls,
 		align,
 		children,
 		className,
@@ -21,7 +22,7 @@ export function useText(props) {
 		highlightWords = [],
 		highlightSanitize,
 		isBlock = false,
-		lineHeight = 1.2,
+		lineHeight: lineHeightProp,
 		optimizeReadabilityFor,
 		size,
 		truncate = false,
@@ -48,6 +49,11 @@ export function useText(props) {
 	const classes = useMemo(() => {
 		const sx = {};
 
+		const lineHeight = getLineHeight({
+			lineHeight: lineHeightProp,
+			adjustLineHeightForInnerControls,
+		});
+
 		sx.Base = css({
 			color,
 			display,
@@ -66,8 +72,8 @@ export function useText(props) {
 				getOptimalTextShade(optimizeReadabilityFor) === 'dark';
 
 			sx.optimalTextColor = isOptimalTextColorDark
-				? css({ color: get('black') })
-				: css({ color: get('white') });
+				? css({ color: ui.get('black') })
+				: css({ color: ui.get('white') });
 		}
 
 		return cx(
@@ -83,6 +89,7 @@ export function useText(props) {
 			className,
 		);
 	}, [
+		adjustLineHeightForInnerControls,
 		align,
 		className,
 		color,
@@ -91,7 +98,7 @@ export function useText(props) {
 		isCaption,
 		isDestructive,
 		isHighlighter,
-		lineHeight,
+		lineHeightProp,
 		optimizeReadabilityFor,
 		size,
 		upperCase,
@@ -138,4 +145,28 @@ export function useText(props) {
 		...truncateProps,
 		children: truncate ? truncateProps.children : content,
 	};
+}
+
+function getLineHeight({ adjustLineHeightForInnerControls, lineHeight }) {
+	if (is.defined(lineHeight)) return lineHeight;
+
+	if (!adjustLineHeightForInnerControls) return;
+
+	let value = `calc(${ui.get('controlHeight')} + ${ui.space(2)})`;
+
+	switch (adjustLineHeightForInnerControls) {
+		case 'large':
+			value = `calc(${ui.get('controlHeightLarge')} + ${ui.space(2)})`;
+			break;
+		case 'small':
+			value = `calc(${ui.get('controlHeightSmall')} + ${ui.space(2)})`;
+			break;
+		case 'xSmall':
+			value = `calc(${ui.get('controlHeightXSmall')} + ${ui.space(2)})`;
+			break;
+		default:
+			break;
+	}
+
+	return value;
 }

--- a/packages/components/src/TextInput/__stories__/TextInput.stories.js
+++ b/packages/components/src/TextInput/__stories__/TextInput.stories.js
@@ -1,8 +1,9 @@
+import { ui } from '@wp-g2/styles';
 import React from 'react';
 import NumberFormat from 'react-number-format';
 
 import { Container } from '../../Container';
-import { Text, VStack } from '../../index';
+import { Select, Text, View, VStack } from '../../index';
 import { TextInput } from '../index';
 
 export default {
@@ -55,6 +56,21 @@ export const custom = () => {
 				prefix={'$'}
 				thousandSeparator={true}
 			/>
+		</VStack>
+	);
+};
+
+export const inlineRendering = () => {
+	return (
+		<VStack
+			css={`
+				margin: auto;
+				width: 320px;
+			`}
+		>
+			<Text adjustLineHeightForInnerControls>
+				My site name is <TextInput isInline />
+			</Text>
 		</VStack>
 	);
 };

--- a/packages/components/src/TextInput/useTextInput.js
+++ b/packages/components/src/TextInput/useTextInput.js
@@ -42,6 +42,7 @@ export function useTextInput(props) {
 		format,
 		gap = 2.5,
 		id: idProp,
+		isInline = false,
 		isFocused: isFocusedProp,
 		isCommitOnBlurOrEnter = true,
 		isResizable = false,
@@ -102,6 +103,7 @@ export function useTextInput(props) {
 		error,
 		gap,
 		isFocused,
+		isInline,
 		justify,
 	});
 

--- a/packages/components/src/TextInput/useTextInputState.js
+++ b/packages/components/src/TextInput/useTextInputState.js
@@ -264,12 +264,9 @@ const useFocusHandlers = ({ store }) => {
 		}
 	}, [store]);
 
-	const handleOnFocus = React.useCallback(
-		(event) => {
-			store.setState({ isFocused: true });
-		},
-		[store],
-	);
+	const handleOnFocus = React.useCallback(() => {
+		store.setState({ isFocused: true });
+	}, [store]);
 
 	return {
 		onBlur: handleOnBlur,

--- a/packages/components/src/__tests__/__snapshots__/Components.test.js.snap
+++ b/packages/components/src/__tests__/__snapshots__/Components.test.js.snap
@@ -312,7 +312,7 @@ exports[`props should render Badge 1`] = `
   id="Badge"
 >
   <span
-    class="components-truncate wp-components-truncate components-text wp-components-text css-qnyxla"
+    class="components-truncate wp-components-truncate components-text wp-components-text css-1djx5to"
     data-g2-c16t="true"
     data-g2-component="Text"
   />
@@ -327,7 +327,7 @@ exports[`props should render Badge with css prop 1`] = `
   id="Badge"
 >
   <span
-    class="components-truncate wp-components-truncate components-text wp-components-text css-qnyxla"
+    class="components-truncate wp-components-truncate components-text wp-components-text css-1djx5to"
     data-g2-c16t="true"
     data-g2-component="Text"
   />
@@ -342,7 +342,7 @@ exports[`props should render Badge with css prop 2`] = `
   id="Badge"
 >
   <span
-    class="components-truncate wp-components-truncate components-text wp-components-text css-qnyxla"
+    class="components-truncate wp-components-truncate components-text wp-components-text css-1djx5to"
     data-g2-c16t="true"
     data-g2-component="Text"
   />
@@ -1347,7 +1347,7 @@ exports[`props should render ControlGroupItem with css prop 2`] = `
 
 exports[`props should render ControlLabel 1`] = `
 <label
-  class="components-truncate wp-components-truncate components-text wp-components-text components-control-label wp-components-control-label css-1ppuusk"
+  class="components-truncate wp-components-truncate components-text wp-components-text components-control-label wp-components-control-label css-1kug32t"
   data-g2-c16t="true"
   data-g2-component="ControlLabel"
   id="ControlLabel"
@@ -1356,7 +1356,7 @@ exports[`props should render ControlLabel 1`] = `
 
 exports[`props should render ControlLabel with css prop 1`] = `
 <label
-  class="components-truncate wp-components-truncate components-text wp-components-text components-control-label wp-components-control-label css-1ppuusk"
+  class="components-truncate wp-components-truncate components-text wp-components-text components-control-label wp-components-control-label css-1kug32t"
   data-g2-c16t="true"
   data-g2-component="ControlLabel"
   id="ControlLabel"
@@ -1365,7 +1365,7 @@ exports[`props should render ControlLabel with css prop 1`] = `
 
 exports[`props should render ControlLabel with css prop 2`] = `
 <label
-  class="components-truncate wp-components-truncate components-text wp-components-text components-control-label wp-components-control-label css-1ova00m"
+  class="components-truncate wp-components-truncate components-text wp-components-text components-control-label wp-components-control-label css-rbj5cn"
   data-g2-c16t="true"
   data-g2-component="ControlLabel"
   id="ControlLabel"
@@ -1460,7 +1460,7 @@ exports[`props should render DropdownMenu with css prop 2`] = `
 
 exports[`props should render DropdownMenuHeader 1`] = `
 <div
-  class="components-truncate wp-components-truncate components-text wp-components-text components-heading wp-components-heading components-menu-header wp-components-menu-header components-dropdown-menu-header wp-components-dropdown-menu-header css-1h6b0jy"
+  class="components-truncate wp-components-truncate components-text wp-components-text components-heading wp-components-heading components-menu-header wp-components-menu-header components-dropdown-menu-header wp-components-dropdown-menu-header css-um0ugh"
   data-g2-c16t="true"
   data-g2-component="DropdownMenuHeader"
   id="DropdownMenuHeader"
@@ -1469,7 +1469,7 @@ exports[`props should render DropdownMenuHeader 1`] = `
 
 exports[`props should render DropdownMenuHeader with css prop 1`] = `
 <div
-  class="components-truncate wp-components-truncate components-text wp-components-text components-heading wp-components-heading components-menu-header wp-components-menu-header components-dropdown-menu-header wp-components-dropdown-menu-header css-1h6b0jy"
+  class="components-truncate wp-components-truncate components-text wp-components-text components-heading wp-components-heading components-menu-header wp-components-menu-header components-dropdown-menu-header wp-components-dropdown-menu-header css-um0ugh"
   data-g2-c16t="true"
   data-g2-component="DropdownMenuHeader"
   id="DropdownMenuHeader"
@@ -1478,7 +1478,7 @@ exports[`props should render DropdownMenuHeader with css prop 1`] = `
 
 exports[`props should render DropdownMenuHeader with css prop 2`] = `
 <div
-  class="components-truncate wp-components-truncate components-text wp-components-text components-heading wp-components-heading components-menu-header wp-components-menu-header components-dropdown-menu-header wp-components-dropdown-menu-header css-1pky2c6"
+  class="components-truncate wp-components-truncate components-text wp-components-text components-heading wp-components-heading components-menu-header wp-components-menu-header components-dropdown-menu-header wp-components-dropdown-menu-header css-v19f1h"
   data-g2-c16t="true"
   data-g2-component="DropdownMenuHeader"
   id="DropdownMenuHeader"
@@ -1802,7 +1802,7 @@ exports[`props should render HStack with css prop 2`] = `
 
 exports[`props should render Heading 1`] = `
 <div
-  class="components-truncate wp-components-truncate components-text wp-components-text components-heading wp-components-heading css-ohvggs"
+  class="components-truncate wp-components-truncate components-text wp-components-text components-heading wp-components-heading css-3uc59p"
   data-g2-c16t="true"
   data-g2-component="Heading"
   id="Heading"
@@ -1811,7 +1811,7 @@ exports[`props should render Heading 1`] = `
 
 exports[`props should render Heading with css prop 1`] = `
 <div
-  class="components-truncate wp-components-truncate components-text wp-components-text components-heading wp-components-heading css-ohvggs"
+  class="components-truncate wp-components-truncate components-text wp-components-text components-heading wp-components-heading css-3uc59p"
   data-g2-c16t="true"
   data-g2-component="Heading"
   id="Heading"
@@ -1820,7 +1820,7 @@ exports[`props should render Heading with css prop 1`] = `
 
 exports[`props should render Heading with css prop 2`] = `
 <div
-  class="components-truncate wp-components-truncate components-text wp-components-text components-heading wp-components-heading css-19phb5y"
+  class="components-truncate wp-components-truncate components-text wp-components-text components-heading wp-components-heading css-1udew8m"
   data-g2-c16t="true"
   data-g2-component="Heading"
   id="Heading"
@@ -1899,7 +1899,7 @@ exports[`props should render Image with css prop 2`] = `
 
 exports[`props should render Initials 1`] = `
 <span
-  class="components-truncate wp-components-truncate components-text wp-components-text components-initials wp-components-initials css-1xgp14x"
+  class="components-truncate wp-components-truncate components-text wp-components-text components-initials wp-components-initials css-5jp2hk"
   data-g2-c16t="true"
   data-g2-component="Initials"
   id="Initials"
@@ -1908,7 +1908,7 @@ exports[`props should render Initials 1`] = `
 
 exports[`props should render Initials with css prop 1`] = `
 <span
-  class="components-truncate wp-components-truncate components-text wp-components-text components-initials wp-components-initials css-1xgp14x"
+  class="components-truncate wp-components-truncate components-text wp-components-text components-initials wp-components-initials css-5jp2hk"
   data-g2-c16t="true"
   data-g2-component="Initials"
   id="Initials"
@@ -1917,7 +1917,7 @@ exports[`props should render Initials with css prop 1`] = `
 
 exports[`props should render Initials with css prop 2`] = `
 <span
-  class="components-truncate wp-components-truncate components-text wp-components-text components-initials wp-components-initials css-19jm77f"
+  class="components-truncate wp-components-truncate components-text wp-components-text components-initials wp-components-initials css-1ri25et"
   data-g2-c16t="true"
   data-g2-component="Initials"
   id="Initials"
@@ -1926,7 +1926,7 @@ exports[`props should render Initials with css prop 2`] = `
 
 exports[`props should render Link 1`] = `
 <a
-  class="components-truncate wp-components-truncate components-text wp-components-text components-link wp-components-link css-zvxhcg"
+  class="components-truncate wp-components-truncate components-text wp-components-text components-link wp-components-link css-yf2kff"
   data-g2-c16t="true"
   data-g2-component="Link"
   id="Link"
@@ -1935,7 +1935,7 @@ exports[`props should render Link 1`] = `
 
 exports[`props should render Link with css prop 1`] = `
 <a
-  class="components-truncate wp-components-truncate components-text wp-components-text components-link wp-components-link css-zvxhcg"
+  class="components-truncate wp-components-truncate components-text wp-components-text components-link wp-components-link css-yf2kff"
   data-g2-c16t="true"
   data-g2-component="Link"
   id="Link"
@@ -1944,7 +1944,7 @@ exports[`props should render Link with css prop 1`] = `
 
 exports[`props should render Link with css prop 2`] = `
 <a
-  class="components-truncate wp-components-truncate components-text wp-components-text components-link wp-components-link css-p7blea"
+  class="components-truncate wp-components-truncate components-text wp-components-text components-link wp-components-link css-1sx13rm"
   data-g2-c16t="true"
   data-g2-component="Link"
   id="Link"
@@ -2166,7 +2166,7 @@ exports[`props should render Menu with css prop 2`] = `
 
 exports[`props should render MenuHeader 1`] = `
 <div
-  class="components-truncate wp-components-truncate components-text wp-components-text components-heading wp-components-heading components-menu-header wp-components-menu-header css-1h6b0jy"
+  class="components-truncate wp-components-truncate components-text wp-components-text components-heading wp-components-heading components-menu-header wp-components-menu-header css-um0ugh"
   data-g2-c16t="true"
   data-g2-component="MenuHeader"
   id="MenuHeader"
@@ -2175,7 +2175,7 @@ exports[`props should render MenuHeader 1`] = `
 
 exports[`props should render MenuHeader with css prop 1`] = `
 <div
-  class="components-truncate wp-components-truncate components-text wp-components-text components-heading wp-components-heading components-menu-header wp-components-menu-header css-1h6b0jy"
+  class="components-truncate wp-components-truncate components-text wp-components-text components-heading wp-components-heading components-menu-header wp-components-menu-header css-um0ugh"
   data-g2-c16t="true"
   data-g2-component="MenuHeader"
   id="MenuHeader"
@@ -2184,7 +2184,7 @@ exports[`props should render MenuHeader with css prop 1`] = `
 
 exports[`props should render MenuHeader with css prop 2`] = `
 <div
-  class="components-truncate wp-components-truncate components-text wp-components-text components-heading wp-components-heading components-menu-header wp-components-menu-header css-1pky2c6"
+  class="components-truncate wp-components-truncate components-text wp-components-text components-heading wp-components-heading components-menu-header wp-components-menu-header css-v19f1h"
   data-g2-c16t="true"
   data-g2-component="MenuHeader"
   id="MenuHeader"
@@ -2667,7 +2667,7 @@ exports[`props should render SearchInput 1`] = `
     class="css-tn92r9"
   >
     <span
-      class="components-truncate wp-components-truncate components-text wp-components-text css-1j5v64k"
+      class="components-truncate wp-components-truncate components-text wp-components-text css-fd3l03"
       data-g2-c16t="true"
       data-g2-component="Text"
     >
@@ -2873,7 +2873,7 @@ exports[`props should render Select 1`] = `
     data-g2-component="FlexItem"
   >
     <span
-      class="components-truncate wp-components-truncate components-text wp-components-text css-1fdlgmt"
+      class="components-truncate wp-components-truncate components-text wp-components-text css-duu1p5"
       data-g2-c16t="true"
       data-g2-component="Text"
     >
@@ -3554,7 +3554,7 @@ exports[`props should render Stepper with css prop 2`] = `
 
 exports[`props should render Subheading 1`] = `
 <div
-  class="components-truncate wp-components-truncate components-text wp-components-text components-subheading wp-components-subheading css-epbge3"
+  class="components-truncate wp-components-truncate components-text wp-components-text components-subheading wp-components-subheading css-8r4buc"
   data-g2-c16t="true"
   data-g2-component="Subheading"
   id="Subheading"
@@ -3563,7 +3563,7 @@ exports[`props should render Subheading 1`] = `
 
 exports[`props should render Subheading with css prop 1`] = `
 <div
-  class="components-truncate wp-components-truncate components-text wp-components-text components-subheading wp-components-subheading css-epbge3"
+  class="components-truncate wp-components-truncate components-text wp-components-text components-subheading wp-components-subheading css-8r4buc"
   data-g2-c16t="true"
   data-g2-component="Subheading"
   id="Subheading"
@@ -3572,7 +3572,7 @@ exports[`props should render Subheading with css prop 1`] = `
 
 exports[`props should render Subheading with css prop 2`] = `
 <div
-  class="components-truncate wp-components-truncate components-text wp-components-text components-subheading wp-components-subheading css-v4ngji"
+  class="components-truncate wp-components-truncate components-text wp-components-text components-subheading wp-components-subheading css-1q81lw9"
   data-g2-c16t="true"
   data-g2-component="Subheading"
   id="Subheading"
@@ -3772,7 +3772,7 @@ exports[`props should render Tag 1`] = `
   id="Tag"
 >
   <span
-    class="components-truncate wp-components-truncate components-text wp-components-text css-1ejcfnr"
+    class="components-truncate wp-components-truncate components-text wp-components-text css-spr0sd"
     data-g2-c16t="true"
     data-g2-component="Text"
   />
@@ -3787,7 +3787,7 @@ exports[`props should render Tag with css prop 1`] = `
   id="Tag"
 >
   <span
-    class="components-truncate wp-components-truncate components-text wp-components-text css-1ejcfnr"
+    class="components-truncate wp-components-truncate components-text wp-components-text css-spr0sd"
     data-g2-c16t="true"
     data-g2-component="Text"
   />
@@ -3802,7 +3802,7 @@ exports[`props should render Tag with css prop 2`] = `
   id="Tag"
 >
   <span
-    class="components-truncate wp-components-truncate components-text wp-components-text css-1ejcfnr"
+    class="components-truncate wp-components-truncate components-text wp-components-text css-spr0sd"
     data-g2-c16t="true"
     data-g2-component="Text"
   />
@@ -3811,7 +3811,7 @@ exports[`props should render Tag with css prop 2`] = `
 
 exports[`props should render Text 1`] = `
 <span
-  class="components-truncate wp-components-truncate components-text wp-components-text css-1j5v64k"
+  class="components-truncate wp-components-truncate components-text wp-components-text css-fd3l03"
   data-g2-c16t="true"
   data-g2-component="Text"
   id="Text"
@@ -3820,7 +3820,7 @@ exports[`props should render Text 1`] = `
 
 exports[`props should render Text with css prop 1`] = `
 <span
-  class="components-truncate wp-components-truncate components-text wp-components-text css-1j5v64k"
+  class="components-truncate wp-components-truncate components-text wp-components-text css-fd3l03"
   data-g2-c16t="true"
   data-g2-component="Text"
   id="Text"
@@ -3829,7 +3829,7 @@ exports[`props should render Text with css prop 1`] = `
 
 exports[`props should render Text with css prop 2`] = `
 <span
-  class="components-truncate wp-components-truncate components-text wp-components-text css-1ihycc6"
+  class="components-truncate wp-components-truncate components-text wp-components-text css-1kyj85n"
   data-g2-c16t="true"
   data-g2-component="Text"
   id="Text"

--- a/packages/components/types/components/BaseField.d.ts
+++ b/packages/components/types/components/BaseField.d.ts
@@ -16,6 +16,12 @@ export declare type BaseFieldProps = FlexProps &
 		 */
 		isFocused?: boolean;
 		/**
+		 * Renders as an inline element (layout).
+		 *
+		 * @default false
+		 */
+		isInline?: boolean;
+		/**
 		 * Renders a subtle variant.
 		 *
 		 * @default false

--- a/packages/components/types/components/Text.d.ts
+++ b/packages/components/types/components/Text.d.ts
@@ -1,6 +1,13 @@
 import { PolymorphicComponent, CSS } from './_shared';
 import { TruncateProps } from './Truncate';
 
+export declare type TextAdjustLineHeightForInnerControls =
+	| boolean
+	| 'large'
+	| 'medium'
+	| 'small'
+	| 'xSmall';
+
 export declare type TextSize =
 	| 'body'
 	| 'caption'
@@ -40,6 +47,23 @@ export declare type TextProps = TruncateProps & {
 	 *```
 	 */
 	align?: CSS['textAlign'];
+	/**
+	 * Automatically calculate the appropriate line-height value for contents that render text and Control elements (e.g. `TextInput`).
+	 *
+	 * @example
+	 * ```jsx
+	 * import { Text, TextInput } from `@wp-g2/components`
+	 *
+	 * function Example() {
+	 * 	return (
+	 * 		<Text adjustLineHeightForInnerControls>
+	 * 			Where the north wind meets the <TextInput value="sea..." />
+	 * 		</Text>
+	 * 	)
+	 * }
+	 *```
+	 */
+	adjustLineHeightForInnerControls?: TextAdjustLineHeightForInnerControls;
 	/**
 	 * Adjusts the text color.
 	 */

--- a/packages/styles/src/mixins/browsers.js
+++ b/packages/styles/src/mixins/browsers.js
@@ -1,0 +1,34 @@
+import { css } from '../style-system';
+
+export function ieOnly(strings, ...interpolations) {
+	const interpolatedStyles = css(strings, ...interpolations);
+
+	return css`
+		@media screen and (-ms-high-contrast: active),
+			(-ms-high-contrast: none) {
+			${interpolatedStyles};
+		}
+	`;
+}
+
+export function firefoxOnly(strings, ...interpolations) {
+	const interpolatedStyles = css(strings, ...interpolations);
+
+	return css`
+		@-moz-document url-prefix() {
+			${interpolatedStyles};
+		}
+	`;
+}
+
+export function safariOnly(strings, ...interpolations) {
+	const interpolatedStyles = css(strings, ...interpolations);
+
+	return css`
+		@media not all and (min-resolution: 0.001dpcm) {
+			@supports (-webkit-appearance: none) {
+				${interpolatedStyles}
+			}
+		}
+	`;
+}

--- a/packages/styles/src/mixins/index.js
+++ b/packages/styles/src/mixins/index.js
@@ -1,5 +1,6 @@
 export * from './backgrounds';
 export * from './breakpoints';
+export * from './browsers';
 export * from './colorBlindMode';
 export * from './darkMode';
 export * from './device';

--- a/packages/styles/src/presets/browsers.js
+++ b/packages/styles/src/presets/browsers.js
@@ -1,0 +1,7 @@
+import { firefoxOnly, ieOnly, safariOnly } from '../mixins/browsers';
+
+export const browsers = {};
+
+browsers.ie = ieOnly;
+browsers.firefox = firefoxOnly;
+browsers.safari = safariOnly;

--- a/packages/styles/src/presets/ui.js
+++ b/packages/styles/src/presets/ui.js
@@ -2,6 +2,7 @@ import { alignment } from './alignments';
 import { animation } from './animations';
 import { background } from './backgrounds';
 import { border, borderRadius } from './borders';
+import { browsers } from './browsers';
 import { color } from './colors';
 import { css } from './css';
 import { frame } from './dimensions';
@@ -26,6 +27,7 @@ export const ui = {
 	background,
 	border,
 	borderRadius,
+	browsers,
 	color,
 	createToken,
 	css,

--- a/packages/styles/src/theme/config.js
+++ b/packages/styles/src/theme/config.js
@@ -61,6 +61,7 @@ const FONT_PROPS = {
 	fontSizeMobile: '15px',
 	fontSizeSmall: `calc(0.92 * ${get('fontSize')})`,
 	fontSizeXSmall: `calc(0.75 * ${get('fontSize')})`,
+	fontLineHeightBase: '1.2',
 };
 
 const SURFACE_PROPS = {

--- a/packages/styles/types/presets/browsers.d.ts
+++ b/packages/styles/types/presets/browsers.d.ts
@@ -1,0 +1,11 @@
+import { CSSClassName } from '../shared';
+
+/** Render styles for specific browsers. */
+export declare interface BrowsersInterface {
+	/** Renders styles for IE 10+ only. */
+	ie: CSSClassName;
+	/** Renders styles for Firefox only. */
+	firefox: CSSClassName;
+	/** Renders styles for Safari only. */
+	safari: CSSClassName;
+}

--- a/packages/styles/types/presets/ui.d.ts
+++ b/packages/styles/types/presets/ui.d.ts
@@ -4,6 +4,7 @@ import { AlignmentInterface } from './alignments';
 import { AnimationInterface } from './animations';
 import { BackgroundInterface } from './backgrounds';
 import { BorderInterface, BorderRadiusInterface } from './borders';
+import { BrowsersInterface } from './browsers';
 import { ColorInterface } from './colors';
 import { CSSInterface } from './css';
 import { FrameInterface } from './dimensions';
@@ -64,6 +65,8 @@ export declare interface SystemInterface {
 	borderRadius: BorderRadiusInterface;
 	/** Modify border styles based on system presets. */
 	border: BorderInterface;
+	/** Render styles for specific browsers. */
+	browsers: BrowsersInterface;
 	/**
 	 * Get a color value.
 	 * @alias ui.values.color


### PR DESCRIPTION
<img width="469" alt="Screen Shot 2020-11-04 at 3 04 43 PM" src="https://user-images.githubusercontent.com/2322354/98171530-e257f700-1ebd-11eb-8587-e4966bc2c4ce.png">

This update enables Control components (`TextInput`, `UnitInput`, and `Select`) to render inline with text content.

##### Example:
```jsx
<Text>My name is <TextInput isInline value="Olaf" /></Text>
```

This is achieved by adding a new `isInline` property to the control components (which is ultimately handled by the underlying `BaseField` component).

### ✨ Auto-mathematical `lineHeight`

To ensure the (inner) controls of a `Text` based component can align correctly with text content, I've added a `adjustLineHeightForInnerControls` prop to help automagically calculate the optimal line-height for the components.

### 🧭 Browser Mixins/Presets

During development, I noticed some weird text alignment rendering with Safari. This update adds a handful of browser specific CSS mixins to target custom styles for a given browser. These mixins have been made available to the `ui` preset collection.

---

### 🕹 Testing

Check this test preview URL. Ensure that the input aligns with the text:

https://g2-git-update-controls-inline-with-text.itsjonq.vercel.app/iframe.html?id=components-textinput--inline-rendering&viewMode=story

---

Resolves: https://github.com/ItsJonQ/g2/issues/78