### PR TITLE
Select: Add option grouping, placeholder, and multiple support

### DIFF
--- a/packages/components/src/Select/Select.js
+++ b/packages/components/src/Select/Select.js
@@ -9,9 +9,14 @@ import SelectArrow from './SelectArrow';
 import { useSelect } from './useSelect';
 
 function Select(props, forwardedRef) {
-	const { inputProps, inputRef, prefix, suffix, ...otherProps } = useSelect(
-		props,
-	);
+	const {
+		inputProps,
+		inputRef,
+		multiple,
+		prefix,
+		suffix,
+		...otherProps
+	} = useSelect(props);
 
 	return (
 		<View {...otherProps}>
@@ -22,7 +27,7 @@ function Select(props, forwardedRef) {
 				ref={mergeRefs([forwardedRef, inputRef])}
 			/>
 			{suffix && <FlexItem {...ui.$('SelectSuffix')}>{suffix}</FlexItem>}
-			<SelectArrow />
+			{!multiple && <SelectArrow />}
 		</View>
 	);
 }

--- a/packages/components/src/Select/Select.js
+++ b/packages/components/src/Select/Select.js
@@ -1,151 +1,30 @@
-import { contextConnect, useContextSystem } from '@wp-g2/context';
-import { FiChevronDown } from '@wp-g2/icons';
-import { cx, ui } from '@wp-g2/styles';
-import { mergeRefs, noop, useControlledState } from '@wp-g2/utils';
-import React, { useCallback, useRef, useState } from 'react';
+import { contextConnect } from '@wp-g2/context';
+import { ui } from '@wp-g2/styles';
+import { mergeRefs } from '@wp-g2/utils';
+import React from 'react';
 
-import { useBaseField } from '../BaseField';
 import { FlexItem } from '../Flex';
-import { useFormGroupContextId } from '../FormGroup';
-import { Icon } from '../Icon';
-import { Text } from '../Text';
-import * as TextInputStyles from '../TextInput/TextInput.styles';
 import { View } from '../View';
-import * as styles from './Select.styles';
-
-const { ArrowWrapperView } = styles;
+import SelectArrow from './SelectArrow';
+import { useSelect } from './useSelect';
 
 function Select(props, forwardedRef) {
-	const {
-		children,
-		className,
-		defaultValue,
-		disabled,
-		error = false,
-		id: idProp,
-		isInline = false,
-		isFocused: isFocusedProp = false,
-		isSubtle,
-		onBlur = noop,
-		onChange = noop,
-		onFocus = noop,
-		options = [],
-		prefix,
-		size,
-		suffix,
-		value: valueProp,
-		...otherProps
-	} = useContextSystem(props, 'Select');
-
-	const [value, setValue] = useControlledState(valueProp, {
-		initial: defaultValue,
-	});
-	const [isFocused, setIsFocused] = useState(isFocusedProp);
-	const inputRef = useRef();
-
-	const baseFieldProps = useBaseField({
-		disabled,
-		error,
-		gap: 0,
-		isClickable: true,
-		isFocused,
-		isInline,
-		isSubtle,
-	});
-
-	const id = useFormGroupContextId(idProp);
-
-	const handleOnRootClick = useCallback(() => {
-		inputRef.current.focus();
-	}, []);
-
-	const handleOnBlur = useCallback(
-		(event) => {
-			onBlur(event);
-			setIsFocused(false);
-		},
-		[onBlur],
+	const { inputProps, inputRef, prefix, suffix, ...otherProps } = useSelect(
+		props,
 	);
-
-	const handleOnFocus = useCallback(
-		(event) => {
-			onFocus(event);
-			setIsFocused(true);
-		},
-		[onFocus],
-	);
-
-	const handleOnChange = useCallback(
-		(event) => {
-			const next = event.target.value;
-			setValue(next);
-			onChange(event.target.value, { event });
-		},
-		[onChange, setValue],
-	);
-
-	const classes = cx(baseFieldProps.className, styles.base, className);
-
-	const inputCx = cx(
-		TextInputStyles.Input,
-		styles.select,
-		TextInputStyles[size],
-	);
-
-	const content =
-		children ||
-		options.map((option, index) => {
-			const { id, label, value, ...optionProps } = option;
-
-			return (
-				<option
-					key={id || value || index}
-					value={value}
-					{...optionProps}
-				>
-					{label}
-				</option>
-			);
-		});
 
 	return (
-		<View
-			{...baseFieldProps}
-			className={classes}
-			disabled={disabled}
-			onClick={handleOnRootClick}
-			{...ui.$('SelectWrapper')}
-		>
+		<View {...otherProps}>
 			{prefix && <FlexItem {...ui.$('SelectPrefix')}>{prefix}</FlexItem>}
 			<View
 				as="select"
-				cx={inputCx}
-				disabled={disabled}
-				id={id}
-				onBlur={handleOnBlur}
-				onChange={handleOnChange}
-				onFocus={handleOnFocus}
+				{...inputProps}
 				ref={mergeRefs([forwardedRef, inputRef])}
-				value={value}
-				{...otherProps}
-				{...ui.$('Select')}
-			>
-				{content}
-			</View>
+			/>
 			{suffix && <FlexItem {...ui.$('SelectSuffix')}>{suffix}</FlexItem>}
 			<SelectArrow />
 		</View>
 	);
 }
-
-const SelectArrow = React.memo(() => {
-	return (
-		<ArrowWrapperView>
-			<Text isBlock variant="muted">
-				<Icon icon={<FiChevronDown />} size={14} />
-			</Text>
-		</ArrowWrapperView>
-	);
-});
 
 export default contextConnect(Select, 'Select');

--- a/packages/components/src/Select/Select.styles.js
+++ b/packages/components/src/Select/Select.styles.js
@@ -1,4 +1,4 @@
-import { css, styled } from '@wp-g2/styles';
+import { css, styled, ui } from '@wp-g2/styles';
 
 import { FlexItem } from '../Flex';
 
@@ -21,4 +21,8 @@ export const ArrowWrapperView = styled(FlexItem)`
 	position: absolute;
 	right: 0;
 	top: 0;
+`;
+
+export const placeholder = css`
+	color: ${ui.get('colorTextMuted')};
 `;

--- a/packages/components/src/Select/Select.utils.js
+++ b/packages/components/src/Select/Select.utils.js
@@ -1,0 +1,35 @@
+import { is } from '@wp-g2/utils';
+import React from 'react';
+
+const isGroup = (option) => {
+	return is.object(option) && is.array(option.options);
+};
+
+const renderOption = (option = {}, index) => {
+	const { disabled, id, label, value } = option;
+	const key = id || value || index;
+
+	return (
+		<option disabled={disabled} key={key}>
+			{label}
+		</option>
+	);
+};
+
+export const renderContent = ({ children, options }) => {
+	if (children) return children;
+
+	return options.map((option, index) => {
+		if (isGroup(option)) {
+			const groupKey = option.id || option.label || index;
+
+			return (
+				<optgroup key={groupKey} label={option.label}>
+					{option.options.map(renderOption)}
+				</optgroup>
+			);
+		}
+
+		return renderOption(option, index);
+	});
+};

--- a/packages/components/src/Select/Select.utils.js
+++ b/packages/components/src/Select/Select.utils.js
@@ -10,7 +10,7 @@ const renderOption = (option = {}, index) => {
 	const key = id || value || index;
 
 	return (
-		<option disabled={disabled} key={key}>
+		<option disabled={disabled} key={key} value={value}>
 			{label}
 		</option>
 	);

--- a/packages/components/src/Select/SelectArrow.js
+++ b/packages/components/src/Select/SelectArrow.js
@@ -1,0 +1,20 @@
+import { FiChevronDown } from '@wp-g2/icons';
+import React from 'react';
+
+import { Icon } from '../Icon';
+import { Text } from '../Text';
+import * as styles from './Select.styles';
+
+const { ArrowWrapperView } = styles;
+
+const SelectArrow = () => {
+	return (
+		<ArrowWrapperView>
+			<Text isBlock variant="muted">
+				<Icon icon={<FiChevronDown />} size={14} />
+			</Text>
+		</ArrowWrapperView>
+	);
+};
+
+export default React.memo(SelectArrow);

--- a/packages/components/src/Select/__stories__/Select.stories.js
+++ b/packages/components/src/Select/__stories__/Select.stories.js
@@ -16,3 +16,55 @@ export const _default = () => {
 
 	return <Select options={options} required />;
 };
+
+export const _groups = () => {
+	const [value, setValue] = React.useState(null);
+
+	const options = [
+		{
+			label: 'Frozen',
+			options: [
+				{
+					label: 'Frozen Heart',
+					value: 'frozen-heart',
+				},
+				{
+					label: 'Do You Want To Build A Snowman?',
+					value: 'do-you-want-to-build-a-snowman',
+				},
+				{
+					label: 'First Time In Forever',
+					value: 'first-time-in-forever',
+				},
+			],
+		},
+		{
+			label: 'Frozen 2',
+			options: [
+				{
+					label: 'All Is Found',
+					value: 'all-is-found',
+				},
+				{
+					label: 'Some Things Never Change',
+					value: 'some-things-never-change',
+				},
+				{
+					label: 'Into The Unknown',
+					value: 'into-the-unknown',
+				},
+			],
+		},
+	];
+
+	return (
+		<>
+			<Select
+				onChange={setValue}
+				options={options}
+				placeholder="Select a song"
+				value={value}
+			/>
+		</>
+	);
+};

--- a/packages/components/src/Select/__stories__/Select.stories.js
+++ b/packages/components/src/Select/__stories__/Select.stories.js
@@ -18,7 +18,7 @@ export const _default = () => {
 };
 
 export const _groups = () => {
-	const [value, setValue] = React.useState(null);
+	const [value, setValue] = React.useState('');
 
 	const options = [
 		{
@@ -66,5 +66,19 @@ export const _groups = () => {
 				value={value}
 			/>
 		</>
+	);
+};
+
+export const _multiple = () => {
+	const [value, setValue] = React.useState([]);
+
+	const options = [
+		{ label: 'Today', value: 'today' },
+		{ label: 'Yesterday', value: 'yesterday' },
+		{ label: 'Last 7 days', value: 'lastWeek' },
+	];
+
+	return (
+		<Select multiple onChange={setValue} options={options} value={value} />
 	);
 };

--- a/packages/components/src/Select/__tests__/__snapshots__/Select.test.js.snap
+++ b/packages/components/src/Select/__tests__/__snapshots__/Select.test.js.snap
@@ -71,14 +71,10 @@ exports[`props should render correctly 1`] = `
     data-g2-component="Select"
     id="select"
   >
-    <option
-      value="olaf"
-    >
+    <option>
       Olaf
     </option>
-    <option
-      value="samantha"
-    >
+    <option>
       Samantha
     </option>
   </select>
@@ -133,14 +129,10 @@ exports[`props should render disabled 1`] = `
     disabled=""
     id="select"
   >
-    <option
-      value="olaf"
-    >
+    <option>
       Olaf
     </option>
-    <option
-      value="samantha"
-    >
+    <option>
       Samantha
     </option>
   </select>
@@ -194,14 +186,10 @@ exports[`props should render readOnly 1`] = `
     id="select"
     readonly=""
   >
-    <option
-      value="olaf"
-    >
+    <option>
       Olaf
     </option>
-    <option
-      value="samantha"
-    >
+    <option>
       Samantha
     </option>
   </select>
@@ -255,14 +243,10 @@ exports[`props should render required 1`] = `
     id="select"
     required=""
   >
-    <option
-      value="olaf"
-    >
+    <option>
       Olaf
     </option>
-    <option
-      value="samantha"
-    >
+    <option>
       Samantha
     </option>
   </select>
@@ -315,14 +299,10 @@ exports[`props should render size 1`] = `
     data-g2-component="Select"
     id="select"
   >
-    <option
-      value="olaf"
-    >
+    <option>
       Olaf
     </option>
-    <option
-      value="samantha"
-    >
+    <option>
       Samantha
     </option>
   </select>

--- a/packages/components/src/Select/__tests__/__snapshots__/Select.test.js.snap
+++ b/packages/components/src/Select/__tests__/__snapshots__/Select.test.js.snap
@@ -71,10 +71,14 @@ exports[`props should render correctly 1`] = `
     data-g2-component="Select"
     id="select"
   >
-    <option>
+    <option
+      value="olaf"
+    >
       Olaf
     </option>
-    <option>
+    <option
+      value="samantha"
+    >
       Samantha
     </option>
   </select>
@@ -129,10 +133,14 @@ exports[`props should render disabled 1`] = `
     disabled=""
     id="select"
   >
-    <option>
+    <option
+      value="olaf"
+    >
       Olaf
     </option>
-    <option>
+    <option
+      value="samantha"
+    >
       Samantha
     </option>
   </select>
@@ -186,10 +194,14 @@ exports[`props should render readOnly 1`] = `
     id="select"
     readonly=""
   >
-    <option>
+    <option
+      value="olaf"
+    >
       Olaf
     </option>
-    <option>
+    <option
+      value="samantha"
+    >
       Samantha
     </option>
   </select>
@@ -243,10 +255,14 @@ exports[`props should render required 1`] = `
     id="select"
     required=""
   >
-    <option>
+    <option
+      value="olaf"
+    >
       Olaf
     </option>
-    <option>
+    <option
+      value="samantha"
+    >
       Samantha
     </option>
   </select>
@@ -299,10 +315,14 @@ exports[`props should render size 1`] = `
     data-g2-component="Select"
     id="select"
   >
-    <option>
+    <option
+      value="olaf"
+    >
       Olaf
     </option>
-    <option>
+    <option
+      value="samantha"
+    >
       Samantha
     </option>
   </select>

--- a/packages/components/src/Select/useSelect.js
+++ b/packages/components/src/Select/useSelect.js
@@ -1,0 +1,133 @@
+import { useContextSystem } from '@wp-g2/context';
+import { cx, ui } from '@wp-g2/styles';
+import { is, noop, useControlledState } from '@wp-g2/utils';
+import React from 'react';
+import { useCallback, useRef, useState } from 'react';
+
+import { useBaseField } from '../BaseField';
+import { useFormGroupContextId } from '../FormGroup';
+import * as TextInputStyles from '../TextInput/TextInput.styles';
+import * as styles from './Select.styles';
+import { renderContent } from './Select.utils';
+
+const PLACEHOLDER_VALUE = '';
+
+export function useSelect(props) {
+	const {
+		children,
+		className,
+		defaultValue = PLACEHOLDER_VALUE,
+		disabled,
+		error = false,
+		id: idProp,
+		isInline = false,
+		isFocused: isFocusedProp = false,
+		isSubtle,
+		onBlur = noop,
+		onChange = noop,
+		onFocus = noop,
+		options = [],
+		placeholder: placeholderProp,
+		prefix,
+		size,
+		suffix,
+		value: valueProp,
+		...otherProps
+	} = useContextSystem(props, 'Select');
+
+	const [value, setValue] = useControlledState(valueProp, {
+		initial: defaultValue,
+	});
+	const [isFocused, setIsFocused] = useState(isFocusedProp);
+	const inputRef = useRef();
+
+	const baseFieldProps = useBaseField({
+		disabled,
+		error,
+		gap: 0,
+		isClickable: true,
+		isFocused,
+		isInline,
+		isSubtle,
+	});
+
+	const id = useFormGroupContextId(idProp);
+
+	const handleOnRootClick = useCallback(() => {
+		inputRef.current.focus();
+	}, []);
+
+	const handleOnBlur = useCallback(
+		(event) => {
+			onBlur(event);
+			setIsFocused(false);
+		},
+		[onBlur],
+	);
+
+	const handleOnFocus = useCallback(
+		(event) => {
+			onFocus(event);
+			setIsFocused(true);
+		},
+		[onFocus],
+	);
+
+	const handleOnChange = useCallback(
+		(event) => {
+			const next = event.target.value;
+			setValue(next);
+			onChange(event.target.value, { event });
+		},
+		[onChange, setValue],
+	);
+
+	const shouldRenderPlaceholder =
+		(!is.defined(value) || is.empty(value)) && is.string(placeholderProp);
+
+	const classes = cx(baseFieldProps.className, styles.base, className);
+
+	const inputClasses = cx(
+		TextInputStyles.Input,
+		styles.select,
+		shouldRenderPlaceholder && styles.placeholder,
+		TextInputStyles[size],
+	);
+
+	let content = renderContent({ children, options });
+
+	if (shouldRenderPlaceholder) {
+		content = (
+			<>
+				<option disabled value={PLACEHOLDER_VALUE}>
+					{placeholderProp}
+				</option>
+				{content}
+			</>
+		);
+	}
+
+	const inputProps = {
+		children: content,
+		className: inputClasses,
+		id,
+		disabled,
+		onChange: handleOnChange,
+		onBlur: handleOnBlur,
+		onFocus: handleOnFocus,
+		value,
+		...ui.$('Select'),
+		...otherProps,
+	};
+
+	return {
+		...baseFieldProps,
+		...ui.$('SelectWrapper'),
+		className: classes,
+		onClick: handleOnRootClick,
+		inputProps,
+		prefix,
+		inputRef,
+		suffix,
+	};
+}

--- a/packages/components/src/Select/useSelect.js
+++ b/packages/components/src/Select/useSelect.js
@@ -6,6 +6,7 @@ import { useCallback, useRef, useState } from 'react';
 
 import { useBaseField } from '../BaseField';
 import { useFormGroupContextId } from '../FormGroup';
+import * as ScrollableStyles from '../Scrollable/Scrollable.styles';
 import * as TextInputStyles from '../TextInput/TextInput.styles';
 import * as styles from './Select.styles';
 import { renderContent } from './Select.utils';
@@ -23,6 +24,7 @@ export function useSelect(props) {
 		isInline = false,
 		isFocused: isFocusedProp = false,
 		isSubtle,
+		multiple,
 		onBlur = noop,
 		onChange = noop,
 		onFocus = noop,
@@ -36,7 +38,7 @@ export function useSelect(props) {
 	} = useContextSystem(props, 'Select');
 
 	const [value, setValue] = useControlledState(valueProp, {
-		initial: defaultValue,
+		initial: multiple ? [] : defaultValue,
 	});
 	const [isFocused, setIsFocused] = useState(isFocusedProp);
 	const inputRef = useRef();
@@ -75,11 +77,20 @@ export function useSelect(props) {
 
 	const handleOnChange = useCallback(
 		(event) => {
-			const next = event.target.value;
+			let next;
+
+			if (multiple) {
+				next = Array.from(event.target.options)
+					.filter(({ selected }) => selected)
+					.map(({ value }) => value);
+			} else {
+				next = event.target.value;
+			}
+
 			setValue(next);
-			onChange(event.target.value, { event });
+			onChange(next, { event });
 		},
-		[onChange, setValue],
+		[onChange, setValue, multiple],
 	);
 
 	const shouldRenderPlaceholder =
@@ -91,6 +102,7 @@ export function useSelect(props) {
 		TextInputStyles.Input,
 		styles.select,
 		shouldRenderPlaceholder && styles.placeholder,
+		multiple && ScrollableStyles.scrollableScrollbar,
 		TextInputStyles[size],
 	);
 
@@ -115,6 +127,7 @@ export function useSelect(props) {
 		onChange: handleOnChange,
 		onBlur: handleOnBlur,
 		onFocus: handleOnFocus,
+		multiple,
 		value,
 		...ui.$('Select'),
 		...otherProps,
@@ -126,6 +139,7 @@ export function useSelect(props) {
 		className: classes,
 		onClick: handleOnRootClick,
 		inputProps,
+		multiple,
 		prefix,
 		inputRef,
 		suffix,

--- a/packages/components/src/TextInput/__stories__/TextInput.stories.js
+++ b/packages/components/src/TextInput/__stories__/TextInput.stories.js
@@ -12,7 +12,7 @@ export default {
 };
 
 export const _default = () => {
-	return <TextInput />;
+	return <TextInput placeholder="Into The Unknown" />;
 };
 
 export const number = () => {

--- a/packages/components/types/components/Select.d.ts
+++ b/packages/components/types/components/Select.d.ts
@@ -8,9 +8,9 @@ import { BaseFieldProps } from './BaseField';
 
 type SelectOption = {
 	id?: string;
-	value?: string;
+	value: string;
 	disabled?: boolean;
-	label?: string;
+	label: string;
 };
 
 type SelectOptionGroup = {
@@ -35,6 +35,10 @@ export declare type SelectProps = Omit<
 		 * ```
 		 */
 		isSubtle?: boolean;
+		/**
+		 * Enables selection of multiple values.
+		 */
+		multiple?: boolean;
 		/**
 		 * Options to render within `Select`.
 		 *
@@ -85,7 +89,7 @@ export declare type SelectProps = Omit<
 		 * }
 		 * ```
 		 */
-		options?: Array<SelectOption> | SelectOptionGroup;
+		options?: Array<SelectOption | SelectOptionGroup>;
 		/**
 		 * Example text to display as placeholder.
 		 */
@@ -131,6 +135,11 @@ export declare type SelectProps = Omit<
 		 * ```
 		 */
 		suffix?: React.ReactElement;
+		/**
+		 * Value for the select element.
+		 * An array of values is required for `multiple`.
+		 */
+		value?: string | Array<string>;
 	};
 
 /**

--- a/packages/components/types/components/Select.d.ts
+++ b/packages/components/types/components/Select.d.ts
@@ -15,8 +15,8 @@ type SelectOption = {
 
 type SelectOptionGroup = {
 	id?: string;
-	label?: string;
-	options?: Array<SelectOption>;
+	label: string;
+	options: Array<SelectOption>;
 };
 
 export declare type SelectProps = Omit<

--- a/packages/components/types/components/Select.d.ts
+++ b/packages/components/types/components/Select.d.ts
@@ -6,6 +6,19 @@ import {
 } from './_shared';
 import { BaseFieldProps } from './BaseField';
 
+type SelectOption = {
+	id?: string;
+	value?: string;
+	disabled?: boolean;
+	label?: string;
+};
+
+type SelectOptionGroup = {
+	id?: string;
+	label?: string;
+	options?: Array<SelectOption>;
+};
+
 export declare type SelectProps = Omit<
 	BaseFieldProps,
 	'gap' | 'isClickable' | 'isFocused'
@@ -30,16 +43,53 @@ export declare type SelectProps = Omit<
 		 * import { Select } from `@wp-g2/components`
 		 *
 		 * function Example() {
-		 *	const options = [
-		 *  	{ id: 'elsa', value: 'elsa', label: 'Elsa' },
-		 *  	{ id: 'ana', value: 'ana', label: 'Ana' },
+		 * 	const options = [
+		 * 		{ id: 'elsa', value: 'elsa', label: 'Elsa' },
+		 * 		{ id: 'ana', value: 'ana', label: 'Ana' },
 		 * 	]
 		 *
 		 * 	return <Select options={options} />
 		 * }
 		 * ```
+		 *
+		 * To render options in groups (`optgroup`), provide a collection of objects
+		 * with `label` and `options` properties.
+		 *
+		 * @example
+		 * ```jsx
+		 * import { Select } from `@wp-g2/components`
+		 *
+		 * function Example() {
+		 * 	const options = [
+		 * 		{
+		 * 			label: 'Frozen',
+		 * 			options: [
+		 * 				{
+		 * 					label: 'Into The Unknown',
+		 * 					value: 'into-the-unknown',
+		 * 				},
+		 * 			],
+		 * 		},
+		 * 		{
+		 * 			label: 'Frozen 2',
+		 * 			options: [
+		 * 				{
+		 * 					label: 'Into The Unknown',
+		 * 					value: 'into-the-unknown',
+		 * 				},
+		 * 			],
+		 * 		},
+		 * 	];
+		 *
+		 * 	return <Select options={options} />
+		 * }
+		 * ```
 		 */
-		options?: Array<unknown>;
+		options?: Array<SelectOption> | SelectOptionGroup;
+		/**
+		 * Example text to display as placeholder.
+		 */
+		placeholder?: string;
 		/**
 		 * Renders prefix content within `Select`.
 		 *

--- a/packages/utils/types/index.d.ts
+++ b/packages/utils/types/index.d.ts
@@ -1,3 +1,4 @@
+export * from '@itsjonq/is';
 export { default as hoistNonReactStatics } from 'hoist-non-react-statics';
 export { default as deepEqual } from 'fast-deep-equal';
 export { default as useResizeAware } from 'react-resize-aware';


### PR DESCRIPTION
This update enhances the `Select` component to support grouping (when passing in values via the `options` prop), `placeholder` rendering, and multi-select via the `multiple` attribute.

In addition to adding these features, `Select` was featured to use the hook-based rendering approach (via `useSelect`). Type definitions have also been updated.

### ✋ Placeholder

<img width="603" alt="Screen Shot 2020-11-05 at 3 22 27 PM" src="https://user-images.githubusercontent.com/2322354/98296823-8060c580-1f81-11eb-85cf-d8dad55db03a.png">

A "placeholder" UI can be rendered by providing a `placeholder` (`string`) value.

### 🍇 Groups

<img width="609" alt="Screen Shot 2020-11-05 at 3 22 30 PM" src="https://user-images.githubusercontent.com/2322354/98296898-9ec6c100-1f81-11eb-8374-aa7eacd1ac0a.png">

Automatic `optgroup` rendering can be done by providing `Select` with `options` that look like this:

```js
	const options = [
		{
			label: 'Frozen',
			options: [
				{
					label: 'Frozen Heart',
					value: 'frozen-heart',
				},
				{
					label: 'Do You Want To Build A Snowman?',
					value: 'do-you-want-to-build-a-snowman',
				},
				{
					label: 'First Time In Forever',
					value: 'first-time-in-forever',
				},
			],
		},
		{
			label: 'Frozen 2',
			options: [
				{
					label: 'All Is Found',
					value: 'all-is-found',
				},
				{
					label: 'Some Things Never Change',
					value: 'some-things-never-change',
				},
				{
					label: 'Into The Unknown',
					value: 'into-the-unknown',
				},
			],
		},
	];
```

### 🔢 Multi-Select

<img width="481" alt="Screen Shot 2020-11-05 at 4 01 37 PM" src="https://user-images.githubusercontent.com/2322354/98297001-c4ec6100-1f81-11eb-96c4-5c595dbc5a75.png">

Multi-select can be enabled by passing `Select` a `multiple` prop. This uses the native HTML `select` multiple feature.

---

### 🕹 Testing

Check out the `Select / Groups` and `Select / Multiple` stories.

https://g2-git-update-select-option-groups-and-multiple.itsjonq.vercel.app/?path=/story/components-select--groups

---

Resolves https://github.com/ItsJonQ/g2/issues/86
Resolves https://github.com/ItsJonQ/g2/issues/85