### PR TITLE
Refactor `is` using `lodash`

### DIFF
--- a/packages/utils/src/is.js
+++ b/packages/utils/src/is.js
@@ -1,12 +1,35 @@
-import baseIs from '@itsjonq/is';
+import {
+	isArray,
+	isBoolean,
+	isDate,
+	isFunction,
+	isMap,
+	isNaN,
+	isNil,
+	isNull,
+	isNumber,
+	isObject,
+	isObjectLike,
+	isPlainObject,
+	isRegExp,
+	isSet,
+	isString,
+	isSymbol,
+	isUndefined,
+	isWeakMap,
+	isWeakSet,
+} from 'lodash';
 
-export * from '@itsjonq/is';
-
-function isEmpty(o = {}) {
-	return Object.keys(o).length === 0;
+/**
+ * Returns the object type of the given payload
+ */
+function isType(type) {
+	return (o) => {
+		return {}.toString.call(o).slice(8, -1) === type;
+	};
 }
 
-function isNumeric(o) {
+const numeric = (o) => {
 	const obj = typeof o === 'string' ? o.replace(/,/g, '') : o;
 	return (
 		!isNaN(parseFloat(obj)) &&
@@ -14,14 +37,46 @@ function isNumeric(o) {
 		isFinite(obj) &&
 		Object.prototype.toString.call(obj).toLowerCase() !== '[object array]'
 	);
-}
+};
 
-function isNumericZero(o) {
+const numericZero = (o) => {
 	return o === 0 || o === '0';
-}
+};
 
-baseIs.empty = isEmpty;
-baseIs.numeric = isNumeric;
-baseIs.numericZero = isNumericZero;
+const empty = (o = {}) => {
+	return Object.keys(o).length === 0;
+};
 
-export const is = baseIs;
+export const is = {
+	blob: isType('Blob'),
+	defined: (o) => !isNil(o),
+	empty,
+	file: isType('File'),
+	numeric,
+	numericZero,
+
+	/**
+	 * Re-exports from lodash
+	 */
+	array: isArray,
+	boolean: isBoolean,
+	date: isDate,
+	function: isFunction,
+	map: isMap,
+	nan: isNaN,
+	nil: isNil,
+	number: isNumber,
+	null: isNull,
+	object: isObject,
+	objectLike: isObjectLike,
+	plainObject: isPlainObject,
+	regExp: isRegExp,
+	set: isSet,
+	string: isString,
+	symbol: isSymbol,
+	undefined: isUndefined,
+	weakSet: isWeakSet,
+	weakMap: isWeakMap,
+};
+
+export default is;


### PR DESCRIPTION
Refactors the internal `is` library to basically re-export some lodash functions with a few extras based on https://github.com/ItsJonQ/is

### Testing instructions

Ensure all existing components continue to work.

Closes https://github.com/ItsJonQ/g2/issues/91