### PR TITLE
Components: ExternalLink

### DIFF
--- a/packages/components/src/ExternalLink/ExternalLink.js
+++ b/packages/components/src/ExternalLink/ExternalLink.js
@@ -3,20 +3,16 @@ import { FiExternalLink } from '@wp-g2/icons';
 import React from 'react';
 
 import { Icon } from '../Icon';
+import { Link } from '../Link';
 import { VisuallyHidden } from '../VisuallyHidden';
 import * as styles from './ExternalLink.styles';
 
 function ExternalLink(props, forwardedRef) {
-	const { children, href, rel, ...otherProps } = useContextSystem(
-		props,
-		'ExternalLink',
-	);
+	const { children, ...otherProps } = useContextSystem(props, 'ExternalLink');
 
 	return (
-		<a
-			href={href}
+		<Link
 			ref={forwardedRef}
-			rel={rel}
 			// eslint-disable-next-line react/jsx-no-target-blank
 			target="_blank"
 			{...otherProps}
@@ -25,11 +21,12 @@ function ExternalLink(props, forwardedRef) {
 			{children}
 			<Icon
 				className={styles.Icon}
+				color="currentColor"
 				icon={<FiExternalLink />}
 				inline
 				size="15"
 			/>
-		</a>
+		</Link>
 	);
 }
 

--- a/packages/components/src/ExternalLink/ExternalLink.js
+++ b/packages/components/src/ExternalLink/ExternalLink.js
@@ -1,0 +1,36 @@
+import { contextConnect, useContextSystem } from '@wp-g2/context';
+import { FiExternalLink } from '@wp-g2/icons';
+import React from 'react';
+
+import { Icon } from '../Icon';
+import { VisuallyHidden } from '../VisuallyHidden';
+import * as styles from './ExternalLink.styles';
+
+function ExternalLink(props, forwardedRef) {
+	const { children, href, rel, ...otherProps } = useContextSystem(
+		props,
+		'ExternalLink',
+	);
+
+	return (
+		<a
+			href={href}
+			ref={forwardedRef}
+			rel={rel}
+			// eslint-disable-next-line react/jsx-no-target-blank
+			target="_blank"
+			{...otherProps}
+		>
+			<VisuallyHidden>(opens in a new tab)</VisuallyHidden>
+			{children}
+			<Icon
+				className={styles.Icon}
+				icon={<FiExternalLink />}
+				inline
+				size="15"
+			/>
+		</a>
+	);
+}
+
+export default contextConnect(ExternalLink, 'ExternalLink');

--- a/packages/components/src/ExternalLink/ExternalLink.styles.js
+++ b/packages/components/src/ExternalLink/ExternalLink.styles.js
@@ -1,6 +1,6 @@
-import { css } from '@wp-g2/styles';
+import { css, ui } from '@wp-g2/styles';
 
 export const Icon = css`
-	fill: currentColor;
-	margin-left: 0.1em;
+	margin-left: ${ui.space(1)};
+	margin-top: ${ui.space(-1)};
 `;

--- a/packages/components/src/ExternalLink/ExternalLink.styles.js
+++ b/packages/components/src/ExternalLink/ExternalLink.styles.js
@@ -1,0 +1,6 @@
+import { css } from '@wp-g2/styles';
+
+export const Icon = css`
+	fill: currentColor;
+	margin-left: 0.1em;
+`;

--- a/packages/components/src/ExternalLink/__stories__/ExternalLink.stories.js
+++ b/packages/components/src/ExternalLink/__stories__/ExternalLink.stories.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+import { ExternalLink } from '../index';
+
+export default {
+	component: ExternalLink,
+	title: 'Components/ExternalLink',
+};
+
+export const _default = () => {
+	return <ExternalLink href="https://wordpress.org">WordPress</ExternalLink>;
+};

--- a/packages/components/src/ExternalLink/__tests__/ExternalLink.test.js
+++ b/packages/components/src/ExternalLink/__tests__/ExternalLink.test.js
@@ -1,0 +1,13 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+
+import { ExternalLink } from '../index';
+
+describe('props', () => {
+	test('should render correctly', () => {
+		const { container } = render(
+			<ExternalLink href="https://wordpress.org">WordPress</ExternalLink>,
+		);
+		expect(container.firstChild).toMatchSnapshot();
+	});
+});

--- a/packages/components/src/ExternalLink/__tests__/__snapshots__/ExternalLink.test.js.snap
+++ b/packages/components/src/ExternalLink/__tests__/__snapshots__/ExternalLink.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`props should render correctly 1`] = `
 <a
-  class="components-external-link wp-components-external-link"
+  class="components-truncate wp-components-truncate components-text wp-components-text components-link wp-components-link components-external-link wp-components-external-link css-yf2kff"
   data-g2-c16t="true"
   data-g2-component="ExternalLink"
   href="https://wordpress.org"
@@ -15,7 +15,7 @@ exports[`props should render correctly 1`] = `
   </span>
   WordPress
   <div
-    class="components-icon wp-components-icon css-2ti84e"
+    class="components-icon wp-components-icon css-142kzph"
     data-g2-c16t="true"
     data-g2-component="Icon"
   >

--- a/packages/components/src/ExternalLink/__tests__/__snapshots__/ExternalLink.test.js.snap
+++ b/packages/components/src/ExternalLink/__tests__/__snapshots__/ExternalLink.test.js.snap
@@ -1,0 +1,49 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`props should render correctly 1`] = `
+<a
+  class="components-external-link wp-components-external-link"
+  data-g2-c16t="true"
+  data-g2-component="ExternalLink"
+  href="https://wordpress.org"
+  target="_blank"
+>
+  <span
+    style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; white-space: nowrap; width: 1px;"
+  >
+    (opens in a new tab)
+  </span>
+  WordPress
+  <div
+    class="components-icon wp-components-icon css-2ti84e"
+    data-g2-c16t="true"
+    data-g2-component="Icon"
+  >
+    <svg
+      fill="none"
+      height="15"
+      size="15"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      viewBox="0 0 24 24"
+      width="15"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"
+      />
+      <polyline
+        points="15 3 21 3 21 9"
+      />
+      <line
+        x1="10"
+        x2="21"
+        y1="14"
+        y2="3"
+      />
+    </svg>
+  </div>
+</a>
+`;

--- a/packages/components/src/ExternalLink/index.js
+++ b/packages/components/src/ExternalLink/index.js
@@ -1,0 +1,1 @@
+export { default as ExternalLink } from './ExternalLink';

--- a/packages/components/src/__tests__/__snapshots__/Components.test.js.snap
+++ b/packages/components/src/__tests__/__snapshots__/Components.test.js.snap
@@ -1641,6 +1641,147 @@ exports[`props should render Elevation with css prop 2`] = `
 />
 `;
 
+exports[`props should render ExternalLink 1`] = `
+<a
+  class="components-truncate wp-components-truncate components-text wp-components-text components-link wp-components-link components-external-link wp-components-external-link css-yf2kff"
+  data-g2-c16t="true"
+  data-g2-component="ExternalLink"
+  id="ExternalLink"
+  target="_blank"
+>
+  <span
+    style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; white-space: nowrap; width: 1px;"
+  >
+    (opens in a new tab)
+  </span>
+  <div
+    class="components-icon wp-components-icon css-142kzph"
+    data-g2-c16t="true"
+    data-g2-component="Icon"
+  >
+    <svg
+      fill="none"
+      height="15"
+      size="15"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      viewBox="0 0 24 24"
+      width="15"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"
+      />
+      <polyline
+        points="15 3 21 3 21 9"
+      />
+      <line
+        x1="10"
+        x2="21"
+        y1="14"
+        y2="3"
+      />
+    </svg>
+  </div>
+</a>
+`;
+
+exports[`props should render ExternalLink with css prop 1`] = `
+<a
+  class="components-truncate wp-components-truncate components-text wp-components-text components-link wp-components-link components-external-link wp-components-external-link css-yf2kff"
+  data-g2-c16t="true"
+  data-g2-component="ExternalLink"
+  id="ExternalLink"
+  target="_blank"
+>
+  <span
+    style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; white-space: nowrap; width: 1px;"
+  >
+    (opens in a new tab)
+  </span>
+  <div
+    class="components-icon wp-components-icon css-142kzph"
+    data-g2-c16t="true"
+    data-g2-component="Icon"
+  >
+    <svg
+      fill="none"
+      height="15"
+      size="15"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      viewBox="0 0 24 24"
+      width="15"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"
+      />
+      <polyline
+        points="15 3 21 3 21 9"
+      />
+      <line
+        x1="10"
+        x2="21"
+        y1="14"
+        y2="3"
+      />
+    </svg>
+  </div>
+</a>
+`;
+
+exports[`props should render ExternalLink with css prop 2`] = `
+<a
+  class="components-truncate wp-components-truncate components-text wp-components-text components-link wp-components-link components-external-link wp-components-external-link css-1sx13rm"
+  data-g2-c16t="true"
+  data-g2-component="ExternalLink"
+  id="ExternalLink"
+  target="_blank"
+>
+  <span
+    style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; white-space: nowrap; width: 1px;"
+  >
+    (opens in a new tab)
+  </span>
+  <div
+    class="components-icon wp-components-icon css-142kzph"
+    data-g2-c16t="true"
+    data-g2-component="Icon"
+  >
+    <svg
+      fill="none"
+      height="15"
+      size="15"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      viewBox="0 0 24 24"
+      width="15"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"
+      />
+      <polyline
+        points="15 3 21 3 21 9"
+      />
+      <line
+        x1="10"
+        x2="21"
+        y1="14"
+        y2="3"
+      />
+    </svg>
+  </div>
+</a>
+`;
+
 exports[`props should render Flex 1`] = `
 <div
   class="components-flex wp-components-flex css-1syc9i3"

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -35,6 +35,7 @@ export * from './Debugger';
 export * from './Divider';
 export * from './Dropdown';
 export * from './Elevation';
+export * from './ExternalLink';
 export * from './Flex';
 export * from './FormGroup';
 export * from './Grid';


### PR DESCRIPTION


Adds a new `ExternalLink` component in parity with `@wordpress/components/ExternalLink`.

### WP/Components
<img width="127" alt="Captura de Tela 2020-11-09 às 09 47 11" src="https://user-images.githubusercontent.com/24264157/98577267-8b14a680-2270-11eb-94ee-daf8368c1b97.png">

### G2/Components
<img width="96" alt="Captura de Tela 2020-11-11 às 09 44 29" src="https://user-images.githubusercontent.com/24264157/98845402-81bb4380-2402-11eb-8706-c9b4344f0952.png">

