### PR TITLE
Button: Update focus ring rendering for subtle * control variant

### DIFF
--- a/packages/components/src/Button/Button.styles.js
+++ b/packages/components/src/Button/Button.styles.js
@@ -268,6 +268,8 @@ export const subtleControlActive = css`
 		}
 		&:focus {
 			background: ${ui.get('buttonControlActiveStateColorFocus')};
+			box-shadow: ${ui.get('buttonControlActiveStateBoxShadowFocus')};
+			border-color: ${ui.get('buttonControlActiveStateBorderColorFocus')};
 		}
 		&:active {
 			background: ${ui.get('buttonControlActiveStateColorActive')};

--- a/packages/components/src/ButtonGroup/__tests__/__snapshots__/ButtonGroup.test.js.snap
+++ b/packages/components/src/ButtonGroup/__tests__/__snapshots__/ButtonGroup.test.js.snap
@@ -280,26 +280,30 @@ exports[`props should render correctly 1`] = `
   transition: all 200ms cubic-bezier(0.12, 0.8, 0.32, 1);
   transition: all var(--wp-g2-transition-duration) var(--wp-g2-transition-timing-function-control);
   z-index: 1;
-  background: #007cba;
+  background: #1e1e1e;
   background: var(--wp-g2-button-control-active-state-color);
-  border-color: #007cba;
+  border-color: #1e1e1e;
   border-color: var(--wp-g2-button-control-active-state-color);
   color: #ffffff;
   color: var(--wp-g2-button-control-active-state-text-color);
 }
 
 .emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1[data-active='true']:hover {
-  background: #007cba;
+  background: #1e1e1e;
   background: var(--wp-g2-button-control-active-state-color-hover);
 }
 
 .emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1[data-active='true']:focus {
-  background: #007cba;
+  background: #1e1e1e;
   background: var(--wp-g2-button-control-active-state-color-focus);
+  box-shadow: 0 0 0 0.5px #007cba,0 0 0 2px #ffffff inset;
+  box-shadow: var(--wp-g2-button-control-active-state-box-shadow-focus);
+  border-color: #007cba;
+  border-color: var(--wp-g2-button-control-active-state-border-color-focus);
 }
 
 .emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1[data-active='true']:active {
-  background: #007cba;
+  background: #1e1e1e;
   background: var(--wp-g2-button-control-active-state-color-active);
 }
 

--- a/packages/components/src/ColorControl/__tests__/__snapshots__/ColorControl.test.js.snap
+++ b/packages/components/src/ColorControl/__tests__/__snapshots__/ColorControl.test.js.snap
@@ -257,26 +257,30 @@ exports[`props should render correctly 1`] = `
   transition: all 200ms cubic-bezier(0.12, 0.8, 0.32, 1);
   transition: all var(--wp-g2-transition-duration) var(--wp-g2-transition-timing-function-control);
   z-index: 1;
-  background: #007cba;
+  background: #1e1e1e;
   background: var(--wp-g2-button-control-active-state-color);
-  border-color: #007cba;
+  border-color: #1e1e1e;
   border-color: var(--wp-g2-button-control-active-state-color);
   color: #ffffff;
   color: var(--wp-g2-button-control-active-state-text-color);
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0[data-active='true']:hover {
-  background: #007cba;
+  background: #1e1e1e;
   background: var(--wp-g2-button-control-active-state-color-hover);
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0[data-active='true']:focus {
-  background: #007cba;
+  background: #1e1e1e;
   background: var(--wp-g2-button-control-active-state-color-focus);
+  box-shadow: 0 0 0 0.5px #007cba,0 0 0 2px #ffffff inset;
+  box-shadow: var(--wp-g2-button-control-active-state-box-shadow-focus);
+  border-color: #007cba;
+  border-color: var(--wp-g2-button-control-active-state-border-color-focus);
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0[data-active='true']:active {
-  background: #007cba;
+  background: #1e1e1e;
   background: var(--wp-g2-button-control-active-state-color-active);
 }
 

--- a/packages/components/src/__tests__/__snapshots__/Components.test.js.snap
+++ b/packages/components/src/__tests__/__snapshots__/Components.test.js.snap
@@ -8766,26 +8766,30 @@ exports[`props should render ColorControl 1`] = `
   transition: all 200ms cubic-bezier(0.12, 0.8, 0.32, 1);
   transition: all var(--wp-g2-transition-duration) var(--wp-g2-transition-timing-function-control);
   z-index: 1;
-  background: #007cba;
+  background: #1e1e1e;
   background: var(--wp-g2-button-control-active-state-color);
-  border-color: #007cba;
+  border-color: #1e1e1e;
   border-color: var(--wp-g2-button-control-active-state-color);
   color: #ffffff;
   color: var(--wp-g2-button-control-active-state-text-color);
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0[data-active='true']:hover {
-  background: #007cba;
+  background: #1e1e1e;
   background: var(--wp-g2-button-control-active-state-color-hover);
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0[data-active='true']:focus {
-  background: #007cba;
+  background: #1e1e1e;
   background: var(--wp-g2-button-control-active-state-color-focus);
+  box-shadow: 0 0 0 0.5px #007cba,0 0 0 2px #ffffff inset;
+  box-shadow: var(--wp-g2-button-control-active-state-box-shadow-focus);
+  border-color: #007cba;
+  border-color: var(--wp-g2-button-control-active-state-border-color-focus);
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0[data-active='true']:active {
-  background: #007cba;
+  background: #1e1e1e;
   background: var(--wp-g2-button-control-active-state-color-active);
 }
 
@@ -9303,26 +9307,30 @@ exports[`props should render ColorControl with css prop 1`] = `
   transition: all 200ms cubic-bezier(0.12, 0.8, 0.32, 1);
   transition: all var(--wp-g2-transition-duration) var(--wp-g2-transition-timing-function-control);
   z-index: 1;
-  background: #007cba;
+  background: #1e1e1e;
   background: var(--wp-g2-button-control-active-state-color);
-  border-color: #007cba;
+  border-color: #1e1e1e;
   border-color: var(--wp-g2-button-control-active-state-color);
   color: #ffffff;
   color: var(--wp-g2-button-control-active-state-text-color);
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0[data-active='true']:hover {
-  background: #007cba;
+  background: #1e1e1e;
   background: var(--wp-g2-button-control-active-state-color-hover);
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0[data-active='true']:focus {
-  background: #007cba;
+  background: #1e1e1e;
   background: var(--wp-g2-button-control-active-state-color-focus);
+  box-shadow: 0 0 0 0.5px #007cba,0 0 0 2px #ffffff inset;
+  box-shadow: var(--wp-g2-button-control-active-state-box-shadow-focus);
+  border-color: #007cba;
+  border-color: var(--wp-g2-button-control-active-state-border-color-focus);
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0[data-active='true']:active {
-  background: #007cba;
+  background: #1e1e1e;
   background: var(--wp-g2-button-control-active-state-color-active);
 }
 
@@ -9842,26 +9850,30 @@ exports[`props should render ColorControl with css prop 2`] = `
   transition: all 200ms cubic-bezier(0.12, 0.8, 0.32, 1);
   transition: all var(--wp-g2-transition-duration) var(--wp-g2-transition-timing-function-control);
   z-index: 1;
-  background: #007cba;
+  background: #1e1e1e;
   background: var(--wp-g2-button-control-active-state-color);
-  border-color: #007cba;
+  border-color: #1e1e1e;
   border-color: var(--wp-g2-button-control-active-state-color);
   color: #ffffff;
   color: var(--wp-g2-button-control-active-state-text-color);
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0[data-active='true']:hover {
-  background: #007cba;
+  background: #1e1e1e;
   background: var(--wp-g2-button-control-active-state-color-hover);
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0[data-active='true']:focus {
-  background: #007cba;
+  background: #1e1e1e;
   background: var(--wp-g2-button-control-active-state-color-focus);
+  box-shadow: 0 0 0 0.5px #007cba,0 0 0 2px #ffffff inset;
+  box-shadow: var(--wp-g2-button-control-active-state-box-shadow-focus);
+  border-color: #007cba;
+  border-color: var(--wp-g2-button-control-active-state-border-color-focus);
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0[data-active='true']:active {
-  background: #007cba;
+  background: #1e1e1e;
   background: var(--wp-g2-button-control-active-state-color-active);
 }
 

--- a/packages/styles/src/theme/config.js
+++ b/packages/styles/src/theme/config.js
@@ -194,11 +194,17 @@ const BUTTON_PROPS = {
 	buttonTertiaryBorderColorActive: get('buttonPrimaryColor'),
 	buttonTertiaryBorderColorFocus: get('buttonPrimaryColor'),
 
-	buttonControlActiveStateColor: get('buttonPrimaryColor'),
+	buttonControlActiveStateColor: get('colorText'),
 	buttonControlActiveStateColorHover: get('buttonControlActiveStateColor'),
 	buttonControlActiveStateColorActive: get('buttonControlActiveStateColor'),
 	buttonControlActiveStateColorFocus: get('buttonControlActiveStateColor'),
 	buttonControlActiveStateTextColor: get('buttonPrimaryTextColor'),
+	buttonControlActiveStateBorderColorFocus: get('buttonPrimaryColor'),
+	buttonControlActiveStateBoxShadowFocus: `0 0 0 ${get(
+		'controlBoxShadowFocusSize',
+	)} ${get('buttonPrimaryColor')}, 0 0 0 ${get(
+		'controlPseudoBoxShadowFocusWidth',
+	)} ${get('buttonControlActiveStateTextColor')} inset`,
 };
 
 const CARD_PROPS = {

--- a/packages/styles/src/theme/darkModeConfig.js
+++ b/packages/styles/src/theme/darkModeConfig.js
@@ -6,6 +6,7 @@ const DARK_MODE_PROPS = {
 	...DARK_MODE_COLORS,
 	...DARK_MODE_RGBA_COLORS,
 	buttonPrimaryTextColorActive: get('controlPrimaryTextColorActive'),
+	buttonControlActiveStateTextColor: get('colorTextInverted'),
 	colorBodyBackground: '#18191A',
 	colorDivider: 'rgba(255, 255, 255, 0.1)',
 	colorScrollbarThumb: 'rgba(255, 255, 255, 0.2)',


### PR DESCRIPTION
This update improves the focus ring visibility for the `subtle control` variant of `Button`.
The styles are adjusted to closely match the current implementation within Gutenberg.

GIF demo
![Screen Capture on 2020-11-16 at 09-00-12](https://user-images.githubusercontent.com/2322354/99261676-0931f980-27eb-11eb-8870-4b2a3ae67e77.gif)

The updates involved adding new Theme `config` variables.

### Design Note

At the moment, all focus ring shadows are handled by adding a `0.5px` (config specified) `box-shadow` on the **outside** of the control. For `Button` components in a segmented `ButtonGroup` cluster, we can see a `0.5px` size difference between the borders.

(Zoomed in screenshot)

<img width="616" alt="Screen Shot 2020-11-16 at 9 00 57 AM" src="https://user-images.githubusercontent.com/2322354/99261921-5746fd00-27eb-11eb-993b-b7ed5dfa2d38.png">

If this isn't ideal, we can add some adjustments in the config.

---

Resolves https://github.com/ItsJonQ/g2/issues/108