### PR TITLE
TextInput/UnitInput: Fix disabled handling for suffix controls

### DIFF
--- a/packages/components/src/TextInput/TextInput.styles.js
+++ b/packages/components/src/TextInput/TextInput.styles.js
@@ -84,7 +84,6 @@ export const SpinnerWrapper = css`
 `;
 
 export const Spinner = css`
-	cursor: pointer;
 	height: 24px;
 	margin: 0 -6px 0 0 !important;
 	opacity: 0.6;
@@ -95,6 +94,7 @@ export const SpinnerArrow = css`
 	background-color: transparent;
 	border-radius: ${ui.get('controlBorderRadius')};
 	color: ${ui.get('colorText')};
+	cursor: pointer;
 	padding: 0 2px;
 
 	&:hover:active {
@@ -130,9 +130,14 @@ export const StepperButton = css`
 	&:hover {
 		background-color: ${ui.get('controlBackgroundColorHover')};
 	}
+
 	&:focus {
 		background-color: ${ui.get('controlBackgroundColorHover')};
 		border-color: ${ui.get('colorAdmin')};
+	}
+
+	&[disabled] {
+		pointer-events: none;
 	}
 `;
 

--- a/packages/components/src/UnitInput/UnitInput.js
+++ b/packages/components/src/UnitInput/UnitInput.js
@@ -8,23 +8,30 @@ import UnitInputSelect from './UnitInputSelect';
 import { useUnitInput } from './useUnitInput';
 
 export function UnitInput(props, ref) {
-	const { onSelectChange, unitStore, ...unitInputProps } = useUnitInput(
-		props,
-		ref,
-	);
+	const {
+		disabled,
+		onSelectChange,
+		unitStore,
+		...unitInputProps
+	} = useUnitInput(props, ref);
 	const [value, unit] = unitStore(
 		(state) => [state.parsedValue, state.unit],
 		shallowCompare,
 	);
 
 	const suffix = (
-		<UnitInputSelect onSelectChange={onSelectChange} unit={unit} />
+		<UnitInputSelect
+			disabled={disabled}
+			onSelectChange={onSelectChange}
+			unit={unit}
+		/>
 	);
 
 	return (
 		<TextInput
 			{...unitInputProps}
 			{...ui.$('UnitInput')}
+			disabled={disabled}
 			format="number"
 			suffix={suffix}
 			type="text"

--- a/packages/components/src/UnitInput/UnitInput.styles.js
+++ b/packages/components/src/UnitInput/UnitInput.styles.js
@@ -23,6 +23,10 @@ export const UnitInputSelectUnit = css`
 	}
 `;
 
+export const disabled = css`
+	pointer-events: none;
+`;
+
 export const UnitInputSelectElement = css`
 	appearance: none;
 	border: none;

--- a/packages/components/src/UnitInput/UnitInputSelect.js
+++ b/packages/components/src/UnitInput/UnitInputSelect.js
@@ -6,8 +6,9 @@ import { View } from '../View';
 import * as styles from './UnitInput.styles';
 import { UNITS } from './UnitInput.utils';
 
-function UnitInputSelect({ onSelectChange, unit }) {
+function UnitInputSelect({ disabled, onSelectChange, unit }) {
 	const [isFocused, setFocused] = React.useState(false);
+
 	const handleOnChange = React.useCallback(
 		(event) => {
 			onSelectChange(event.target.value);
@@ -30,6 +31,7 @@ function UnitInputSelect({ onSelectChange, unit }) {
 				className={cx([
 					styles.UnitInputSelectUnit,
 					isFocused && styles.unitSelectFocused,
+					disabled && styles.disabled,
 				])}
 			>
 				{unit}
@@ -37,6 +39,7 @@ function UnitInputSelect({ onSelectChange, unit }) {
 					{...ui.$('UnitInputSelect')}
 					as="select"
 					className={styles.UnitInputSelectElement}
+					disabled={disabled}
 					onBlur={handleOnBlur}
 					onChange={handleOnChange}
 					onClick={handleOnStopPropagation}


### PR DESCRIPTION
This update fixes the inner stepper / unit controls for `TextInput` and `UnitInput` for their disabled state.
These inner controls are no longer tabbable and cannot be interacted with.

<img width="535" alt="Screen Shot 2020-11-16 at 1 43 46 PM" src="https://user-images.githubusercontent.com/2322354/99295019-dc91d800-2812-11eb-9b1d-a042c2d9a525.png">

Resolves https://github.com/ItsJonQ/g2/issues/107