### PR TITLE
Slider: Add support for unit handling

### DIFF
--- a/packages/components/src/Slider/__stories__/Slider.stories.js
+++ b/packages/components/src/Slider/__stories__/Slider.stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { FormGroup } from '../../index';
+import { FormGroup, Text, VStack } from '../../index';
 import { Slider } from '../index';
 
 export default {
@@ -9,9 +9,17 @@ export default {
 };
 
 export const _default = () => {
+	const [value, setValue] = React.useState('50px');
+
 	return (
-		<FormGroup label="Slider">
-			<Slider />
-		</FormGroup>
+		<VStack>
+			<Text>Value: {value}</Text>
+			<FormGroup label="Slider">
+				<Slider onChange={setValue} value={value} />
+			</FormGroup>
+			<FormGroup label="Slider">
+				<Slider onChange={setValue} value={value} />
+			</FormGroup>
+		</VStack>
 	);
 };

--- a/packages/components/src/Slider/__tests__/Slider.test.js
+++ b/packages/components/src/Slider/__tests__/Slider.test.js
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 
 import { Slider } from '../index';
@@ -25,7 +25,70 @@ describe('props', () => {
 	});
 
 	test('should render value', () => {
-		const { container } = render(<Slider id="slider" size="40" />);
+		const { container } = render(<Slider id="slider" value="40" />);
 		expect(container.firstChild).toMatchSnapshot();
+	});
+
+	test('should render unit value', () => {
+		const { container } = render(<Slider id="slider" value="40px" />);
+		const input = container.querySelector('input');
+
+		expect(container.firstChild).toMatchSnapshot();
+		expect(input.value).toEqual('40');
+	});
+
+	test('should include unit in onChange callback (if value contains unit)', () => {
+		let value = '40px';
+		const setValue = (next) => (value = next);
+
+		render(
+			<Slider
+				data-testid="slider"
+				id="slider"
+				onChange={setValue}
+				value={value}
+			/>,
+		);
+
+		const input = screen.getByTestId('slider');
+
+		fireEvent.change(input, { target: { value: 13 } });
+
+		// onChange callback value
+		expect(value).toBe('13px');
+	});
+
+	test('should change unit in onChange callback, if incoming value unit changes', () => {
+		let value = '40px';
+		const setValue = (next) => (value = next);
+
+		const { rerender } = render(
+			<Slider
+				data-testid="slider"
+				id="slider"
+				onChange={setValue}
+				value={value}
+			/>,
+		);
+
+		const input = screen.getByTestId('slider');
+
+		expect(input.value).toBe('40');
+
+		rerender(
+			<Slider
+				data-testid="slider"
+				id="slider"
+				onChange={setValue}
+				value="100%"
+			/>,
+		);
+
+		expect(input.value).toBe('100');
+
+		fireEvent.change(input, { target: { value: 13 } });
+
+		// onChange callback value
+		expect(value).toBe('13%');
 	});
 });

--- a/packages/components/src/Slider/__tests__/__snapshots__/Slider.test.js.snap
+++ b/packages/components/src/Slider/__tests__/__snapshots__/Slider.test.js.snap
@@ -630,6 +630,163 @@ exports[`props should render size 1`] = `
 />
 `;
 
+exports[`props should render unit value 1`] = `
+.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  margin: 0;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: transparent;
+  border: 1px solid transparent;
+  border-radius: 2px;
+  border-radius: var(--wp-g2-control-border-radius);
+  cursor: pointer;
+  display: block;
+  height: 30px;
+  height: var(--wp-g2-control-height);
+  max-width: 100%;
+  min-width: 0;
+  padding: calc(4px * 1);
+  padding: calc(var(--wp-g2-grid-base) * 1);
+  width: 100%;
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
+}
+
+.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0:focus {
+  outline: none;
+}
+
+.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0::-moz-focus-outer {
+  border: 0;
+}
+
+.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0::-webkit-slider-runnable-track {
+  background: linear-gradient( to right, #007cba calc(var(--progress)), rgba(0, 0, 0, 0.1) calc(var(--progress)) );
+  background: linear-gradient( to right, var(--wp-g2-color-admin) calc(var(--progress)), var(--wp-g2-control-background-dim-color) calc(var(--progress)) );
+  border-radius: 2px;
+  height: 2px;
+  will-change: transform;
+}
+
+*:disabled.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0::-webkit-slider-runnable-track {
+  background: rgba(0, 0, 0, 0.1);
+  background: var(--wp-g2-control-background-dim-color);
+}
+
+.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0::-moz-range-track {
+  background: linear-gradient( to right, #007cba calc(var(--progress)), rgba(0, 0, 0, 0.1) calc(var(--progress)) );
+  background: linear-gradient( to right, var(--wp-g2-color-admin) calc(var(--progress)), var(--wp-g2-control-background-dim-color) calc(var(--progress)) );
+  border-radius: 2px;
+  height: 2px;
+  will-change: transform;
+}
+
+*:disabled.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0::-moz-range-track {
+  background: rgba(0, 0, 0, 0.1);
+  background: var(--wp-g2-control-background-dim-color);
+}
+
+.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #007cba;
+  background-color: var(--wp-g2-slider-thumb-background-color);
+  border: 1px solid transparent;
+  border: 1px solid var(--wp-g2-slider-thumb-border-color);
+  border-radius: 50%;
+  box-shadow: none;
+  box-shadow: var(--wp-g2-slider-thumb-box-shadow);
+  cursor: pointer;
+  height: 12px;
+  margin-top: -5px;
+  opacity: 1;
+  width: 12px;
+  -webkit-transition: box-shadow ease 160ms;
+  -webkit-transition: box-shadow ease var(--wp-g2-transition-duration-fast);
+  transition: box-shadow ease 160ms;
+  transition: box-shadow ease var(--wp-g2-transition-duration-fast);
+  will-change: transform;
+}
+
+*:disabled.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0::-webkit-slider-thumb {
+  background: #8a8b8c;
+  background: var(--wp-g2-color-text-muted);
+  border-color: #8a8b8c;
+  border-color: var(--wp-g2-color-text-muted);
+}
+
+.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0::-moz-range-thumb {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #007cba;
+  background-color: var(--wp-g2-slider-thumb-background-color);
+  border: 1px solid transparent;
+  border: 1px solid var(--wp-g2-slider-thumb-border-color);
+  border-radius: 50%;
+  box-shadow: none;
+  box-shadow: var(--wp-g2-slider-thumb-box-shadow);
+  cursor: pointer;
+  height: 12px;
+  margin-top: -5px;
+  opacity: 1;
+  width: 12px;
+  -webkit-transition: box-shadow ease 160ms;
+  -webkit-transition: box-shadow ease var(--wp-g2-transition-duration-fast);
+  transition: box-shadow ease 160ms;
+  transition: box-shadow ease var(--wp-g2-transition-duration-fast);
+  will-change: transform;
+}
+
+*:disabled.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0::-moz-range-thumb {
+  background: #8a8b8c;
+  background: var(--wp-g2-color-text-muted);
+  border-color: #8a8b8c;
+  border-color: var(--wp-g2-color-text-muted);
+}
+
+.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0:focus::-webkit-slider-thumb {
+  box-shadow: 0 0 0 2px #ffffff,0 0 0 calc(2px + 1px) #007cba;
+  box-shadow: var(--wp-g2-control-pseudo-box-shadow-focus-small);
+}
+
+.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0:focus::-moz-range-thumb {
+  box-shadow: 0 0 0 2px #ffffff,0 0 0 calc(2px + 1px) #007cba;
+  box-shadow: var(--wp-g2-control-pseudo-box-shadow-focus-small);
+}
+
+<input
+  class="components-slider wp-components-slider emotion-0"
+  data-g2-c16t="true"
+  data-g2-component="Slider"
+  id="slider"
+  max="100"
+  min="0"
+  style="--progress: 40%;"
+  type="range"
+  value="40"
+/>
+`;
+
 exports[`props should render value 1`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
   box-sizing: border-box;
@@ -781,8 +938,8 @@ exports[`props should render value 1`] = `
   id="slider"
   max="100"
   min="0"
-  style="--progress: 50%;"
+  style="--progress: 40%;"
   type="range"
-  value="50"
+  value="40"
 />
 `;

--- a/packages/components/src/Slider/useSlider.js
+++ b/packages/components/src/Slider/useSlider.js
@@ -1,7 +1,9 @@
 import { useContextSystem } from '@wp-g2/context';
 import { cx } from '@wp-g2/styles';
 import {
+	createUnitValue,
 	interpolate,
+	is,
 	noop,
 	parseUnitValue,
 	useControlledState,
@@ -28,7 +30,7 @@ export function useSlider(props) {
 		value: valueProp,
 		...otherProps
 	} = useContextSystem(props, 'Slider');
-	const [initialValue] = parseUnitValue(valueProp);
+	const [initialValue, initialUnit] = parseUnitValue(valueProp);
 	const [value, setValue] = useControlledState(initialValue, {
 		initial: defaultValue || 50,
 	});
@@ -45,11 +47,19 @@ export function useSlider(props) {
 
 	const handleOnChange = useCallback(
 		(event) => {
-			const next = parseFloat(event.target.value);
-			setValue(next);
+			const nextValue = parseFloat(event.target.value);
+			if (!is.numeric(nextValue)) return;
+
+			let next = nextValue;
+
+			if (initialUnit) {
+				next = createUnitValue(nextValue, initialUnit);
+			}
+
+			setValue(nextValue);
 			onChange(next, { event });
 		},
-		[onChange, setValue],
+		[onChange, setValue, initialUnit],
 	);
 
 	const handleOnFocus = useCallback(

--- a/packages/design-tools/src/__stories__/Presentation/shared.js
+++ b/packages/design-tools/src/__stories__/Presentation/shared.js
@@ -26,7 +26,6 @@ import { ui } from '@wp-g2/styles';
 import { createStore, shallowCompare } from '@wp-g2/substate';
 import { is } from '@wp-g2/utils';
 import React from 'react';
-import CSSUnit from 'units-css';
 
 export const Wrapper = ({ children, title }) => {
 	return (
@@ -277,23 +276,8 @@ export const CombinedFormGroupInputSlider = React.memo(
 		const value = useTypography((state) => state[prop], shallowCompare);
 
 		const handleOnChange = React.useCallback(
-			(value) => {
-				typographyStore.setState((prev) => {
-					// Handles unit changes
-					const unit =
-						CSSUnit.parse(value).unit ||
-						CSSUnit.parse(prev[prop]).unit;
-
-					const { unit: nextUnit, value: nextValue } = CSSUnit.parse(
-						value,
-					);
-
-					let next = unit ? `${nextValue}${unit}` : value;
-
-					if (nextValue === 0 && nextUnit === value) {
-						next = value;
-					}
-
+			(next) => {
+				typographyStore.setState(() => {
 					return { [prop]: next, hasCustomValues: true };
 				});
 			},
@@ -301,7 +285,6 @@ export const CombinedFormGroupInputSlider = React.memo(
 		);
 
 		if (value === null) return null;
-		const cssValue = CSSUnit.parse(value);
 
 		return (
 			<FormGroup
@@ -333,7 +316,7 @@ export const CombinedFormGroupInputSlider = React.memo(
 						max={sliderMax || 20}
 						min={min}
 						onChange={handleOnChange}
-						value={cssValue.value}
+						value={value}
 					/>
 				</Grid>
 			</FormGroup>


### PR DESCRIPTION
This update adds built-in unit handling support for `Slider`. `Slider` now knows how to understand incoming unit values (e.g. `50px`). It also knows how to preserve unit values during an `onChange` event.

For example:

```jsx
const [value, setValue] = useState('50px')

<Slider value={value} onChange={setValue} />
```

The `Slider` will parse and pass the value of `50` to the internal `input`.

During a change, say to a value of `49`, the `onChange` callback will be `49px`. This is because `Slider` accounts for a potential unit passed in via the `value` prop.

`Slider` also knows how to account for situations where the value may change 👍 

Resolves https://github.com/ItsJonQ/g2/issues/109