### PR TITLE
Icon: Improve "fill" color rendering

### DIFF
--- a/packages/components/src/Alert/__tests__/__snapshots__/Alert.test.js.snap
+++ b/packages/components/src/Alert/__tests__/__snapshots__/Alert.test.js.snap
@@ -245,8 +245,6 @@ exports[`props should render as dismissable 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -292,12 +290,9 @@ exports[`props should render as dismissable 1`] = `
   border-color: var(--wp-g2-control-border-color-subtle);
   color: #1e1e1e;
   color: var(--wp-g2-color-text);
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   padding: calc(4px * 0);
   padding: calc(var(--wp-g2-grid-base) * 0);
   color: currentColor;
-  fill: currentColor;
 }
 
 .emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6>*+*:not(marquee) {
@@ -394,8 +389,6 @@ exports[`props should render as dismissable 1`] = `
   border-color: var(--wp-g2-control-border-color-subtle);
   color: #1e1e1e;
   color: var(--wp-g2-color-text);
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
 }
 
 .emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6:focus {
@@ -406,7 +399,6 @@ exports[`props should render as dismissable 1`] = `
 .emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6:hover,
 .emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6:focus {
   color: currentColor;
-  fill: currentColor;
 }
 
 .emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7 {
@@ -461,6 +453,8 @@ exports[`props should render as dismissable 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  color: currentColor;
+  fill: currentColor;
   height: 16px;
   width: 16px;
 }
@@ -1020,8 +1014,6 @@ exports[`props should render with status 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -1067,12 +1059,9 @@ exports[`props should render with status 1`] = `
   border-color: var(--wp-g2-control-border-color-subtle);
   color: #1e1e1e;
   color: var(--wp-g2-color-text);
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   padding: calc(4px * 0);
   padding: calc(var(--wp-g2-grid-base) * 0);
   color: currentColor;
-  fill: currentColor;
 }
 
 .emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7>*+*:not(marquee) {
@@ -1169,8 +1158,6 @@ exports[`props should render with status 1`] = `
   border-color: var(--wp-g2-control-border-color-subtle);
   color: #1e1e1e;
   color: var(--wp-g2-color-text);
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
 }
 
 .emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7:focus {
@@ -1181,7 +1168,6 @@ exports[`props should render with status 1`] = `
 .emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7:hover,
 .emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7:focus {
   color: currentColor;
-  fill: currentColor;
 }
 
 .emotion-8.emotion-8.emotion-8.emotion-8.emotion-8.emotion-8.emotion-8 {
@@ -1236,6 +1222,8 @@ exports[`props should render with status 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  color: currentColor;
+  fill: currentColor;
   height: 16px;
   width: 16px;
 }

--- a/packages/components/src/ArrowIndicator/__tests__/__snapshots__/ArrowIndicator.test.js.snap
+++ b/packages/components/src/ArrowIndicator/__tests__/__snapshots__/ArrowIndicator.test.js.snap
@@ -88,6 +88,8 @@ exports[`props should render correctly 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  color: currentColor;
+  fill: currentColor;
   height: 5px;
   width: 5px;
 }
@@ -226,6 +228,8 @@ exports[`props should render with a custom size 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  color: currentColor;
+  fill: currentColor;
   height: 5px;
   width: 5px;
 }

--- a/packages/components/src/BaseButton/BaseButton.styles.js
+++ b/packages/components/src/BaseButton/BaseButton.styles.js
@@ -13,7 +13,6 @@ export const Button = css`
 	color: ${ui.color.text};
 	cursor: pointer;
 	display: inline-flex;
-	fill: ${ui.color.text};
 	font-size: ${ui.get('fontSize')};
 	line-height: 1;
 	min-height: ${ui.get('controlHeight')};
@@ -63,7 +62,6 @@ export const Button = css`
 
 export const destructive = css`
 	color: ${ui.color.destructive};
-	fill: ${ui.color.destructive};
 `;
 
 export const block = css`
@@ -157,14 +155,12 @@ export const LoadingOverlay = css`
 export const subtle = css`
 	border-color: ${ui.get('controlBorderColorSubtle')};
 	color: ${ui.color.text};
-	fill: ${ui.color.text};
 
 	&:hover,
 	&:active,
 	&:focus {
 		border-color: ${ui.get('controlBorderColorSubtle')};
 		color: ${ui.color.text};
-		fill: ${ui.color.text};
 	}
 
 	&:focus {
@@ -184,7 +180,6 @@ export const control = css`
 	&:active,
 	&:focus {
 		color: ${ui.color.text};
-		fill: ${ui.color.text};
 	}
 
 	&:focus {
@@ -213,7 +208,6 @@ export const subtleControl = css`
 	&[data-active='true'] {
 		background: ${ui.get('colorText')};
 		color: ${ui.get('colorTextInverted')};
-		fill: ${ui.get('colorTextInverted')};
 	}
 `;
 
@@ -224,12 +218,10 @@ export const narrow = css`
 
 export const currentColor = css`
 	color: currentColor;
-	fill: currentColor;
 
 	&:hover,
 	&:focus {
 		color: currentColor;
-		fill: currentColor;
 	}
 `;
 

--- a/packages/components/src/BaseButton/__tests__/__snapshots__/BaseButton.test.js.snap
+++ b/packages/components/src/BaseButton/__tests__/__snapshots__/BaseButton.test.js.snap
@@ -47,8 +47,6 @@ exports[`props should render correctly 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;

--- a/packages/components/src/BlankSlate/__tests__/__snapshots__/BlankSlate.test.js.snap
+++ b/packages/components/src/BlankSlate/__tests__/__snapshots__/BlankSlate.test.js.snap
@@ -235,6 +235,8 @@ exports[`props should render correctly 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  color: currentColor;
+  fill: currentColor;
   height: 20px;
   width: 20px;
   display: inline-block;

--- a/packages/components/src/Button/__tests__/__snapshots__/Button.test.js.snap
+++ b/packages/components/src/Button/__tests__/__snapshots__/Button.test.js.snap
@@ -47,8 +47,6 @@ exports[`props should render (Flex) gap 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -331,8 +329,6 @@ exports[`props should render as link (href) 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -615,8 +611,6 @@ exports[`props should render correctly 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -899,8 +893,6 @@ exports[`props should render disabled 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -1186,8 +1178,6 @@ exports[`props should render elevation 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -1470,8 +1460,6 @@ exports[`props should render hasCaret 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -1687,6 +1675,8 @@ exports[`props should render hasCaret 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  color: currentColor;
+  fill: currentColor;
   height: 16px;
   width: 16px;
 }
@@ -1847,8 +1837,6 @@ exports[`props should render icon 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -2033,6 +2021,8 @@ exports[`props should render icon 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  color: currentColor;
+  fill: currentColor;
   height: 16px;
   width: 16px;
 }
@@ -2216,8 +2206,6 @@ exports[`props should render isControl 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -2366,8 +2354,6 @@ exports[`props should render isControl 1`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0:focus {
   color: #1e1e1e;
   color: var(--wp-g2-color-text);
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0:focus {
@@ -2528,8 +2514,6 @@ exports[`props should render isDestructive 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -2555,8 +2539,6 @@ exports[`props should render isDestructive 1`] = `
   width: auto;
   color: #D94F4F;
   color: var(--wp-g2-color-destructive);
-  fill: #D94F4F;
-  fill: var(--wp-g2-color-destructive);
   text-align: center;
   color: #007cba;
   color: var(--wp-g2-button-text-color);
@@ -2816,8 +2798,6 @@ exports[`props should render isLoading 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -3429,8 +3409,6 @@ exports[`props should render isNarrow 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -3717,8 +3695,6 @@ exports[`props should render isRounded 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -4002,8 +3978,6 @@ exports[`props should render isSubtle 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -4045,8 +4019,6 @@ exports[`props should render isSubtle 1`] = `
   border-color: var(--wp-g2-control-border-color-subtle);
   color: #1e1e1e;
   color: var(--wp-g2-color-text);
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
@@ -4149,8 +4121,6 @@ exports[`props should render isSubtle 1`] = `
   border-color: var(--wp-g2-control-border-color-subtle);
   color: #1e1e1e;
   color: var(--wp-g2-color-text);
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0:focus {
@@ -4308,8 +4278,6 @@ exports[`props should render prefix 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -4639,8 +4607,6 @@ exports[`props should render size 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -4934,8 +4900,6 @@ exports[`props should render suffix 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -5265,8 +5229,6 @@ exports[`props should render variant 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;

--- a/packages/components/src/ButtonGroup/__tests__/__snapshots__/ButtonGroup.test.js.snap
+++ b/packages/components/src/ButtonGroup/__tests__/__snapshots__/ButtonGroup.test.js.snap
@@ -74,8 +74,6 @@ exports[`props should render correctly 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -128,8 +126,6 @@ exports[`props should render correctly 1`] = `
   border-color: var(--wp-g2-control-border-color-subtle);
   color: #1e1e1e;
   color: var(--wp-g2-color-text);
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   background-color: transparent;
 }
 
@@ -231,8 +227,6 @@ exports[`props should render correctly 1`] = `
 .emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1:focus {
   color: #1e1e1e;
   color: var(--wp-g2-color-text);
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
 }
 
 .emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1:focus {
@@ -250,8 +244,6 @@ exports[`props should render correctly 1`] = `
   border-color: var(--wp-g2-control-border-color-subtle);
   color: #1e1e1e;
   color: var(--wp-g2-color-text);
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
 }
 
 .emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1:focus {
@@ -280,8 +272,6 @@ exports[`props should render correctly 1`] = `
   background: var(--wp-g2-color-text);
   color: #ffffff;
   color: var(--wp-g2-color-text-inverted);
-  fill: #ffffff;
-  fill: var(--wp-g2-color-text-inverted);
 }
 
 .emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1[data-active='true'] {

--- a/packages/components/src/Card/__tests__/__snapshots__/Card.test.js.snap
+++ b/packages/components/src/Card/__tests__/__snapshots__/Card.test.js.snap
@@ -286,8 +286,6 @@ exports[`props should render CardInnerBody 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -986,8 +984,6 @@ exports[`props should render correctly 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;

--- a/packages/components/src/ClipboardButton/__tests__/__snapshots__/ClipboardButton.test.js.snap
+++ b/packages/components/src/ClipboardButton/__tests__/__snapshots__/ClipboardButton.test.js.snap
@@ -47,8 +47,6 @@ exports[`props should render correctly 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;

--- a/packages/components/src/CloseButton/__tests__/__snapshots__/CloseButton.test.js.snap
+++ b/packages/components/src/CloseButton/__tests__/__snapshots__/CloseButton.test.js.snap
@@ -47,8 +47,6 @@ exports[`props should render correctly 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -94,8 +92,6 @@ exports[`props should render correctly 1`] = `
   border-color: var(--wp-g2-control-border-color-subtle);
   color: #1e1e1e;
   color: var(--wp-g2-color-text);
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   padding: calc(4px * 0);
   padding: calc(var(--wp-g2-grid-base) * 0);
 }
@@ -194,8 +190,6 @@ exports[`props should render correctly 1`] = `
   border-color: var(--wp-g2-control-border-color-subtle);
   color: #1e1e1e;
   color: var(--wp-g2-color-text);
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0:focus {
@@ -255,6 +249,8 @@ exports[`props should render correctly 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  color: currentColor;
+  fill: currentColor;
   height: 12px;
   width: 12px;
 }
@@ -408,8 +404,6 @@ exports[`props should render size 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -457,8 +451,6 @@ exports[`props should render size 1`] = `
   border-color: var(--wp-g2-control-border-color-subtle);
   color: #1e1e1e;
   color: var(--wp-g2-color-text);
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   padding: calc(4px * 0);
   padding: calc(var(--wp-g2-grid-base) * 0);
 }
@@ -562,8 +554,6 @@ exports[`props should render size 1`] = `
   border-color: var(--wp-g2-control-border-color-subtle);
   color: #1e1e1e;
   color: var(--wp-g2-color-text);
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0:focus {
@@ -623,6 +613,8 @@ exports[`props should render size 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  color: currentColor;
+  fill: currentColor;
   height: 12px;
   width: 12px;
 }
@@ -776,8 +768,6 @@ exports[`props should render variant 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -823,8 +813,6 @@ exports[`props should render variant 1`] = `
   border-color: var(--wp-g2-control-border-color-subtle);
   color: #1e1e1e;
   color: var(--wp-g2-color-text);
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   padding: calc(4px * 0);
   padding: calc(var(--wp-g2-grid-base) * 0);
 }
@@ -933,8 +921,6 @@ exports[`props should render variant 1`] = `
   border-color: var(--wp-g2-control-border-color-subtle);
   color: #1e1e1e;
   color: var(--wp-g2-color-text);
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0:focus {
@@ -994,6 +980,8 @@ exports[`props should render variant 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  color: currentColor;
+  fill: currentColor;
   height: 12px;
   width: 12px;
 }

--- a/packages/components/src/Collapsible/__tests__/__snapshots__/Collapsible.test.js.snap
+++ b/packages/components/src/Collapsible/__tests__/__snapshots__/Collapsible.test.js.snap
@@ -70,8 +70,6 @@ exports[`props should render correctly 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -440,8 +438,6 @@ exports[`props should render visible 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;

--- a/packages/components/src/ColorCircle/__tests__/__snapshots__/ColorCircle.test.js.snap
+++ b/packages/components/src/ColorCircle/__tests__/__snapshots__/ColorCircle.test.js.snap
@@ -96,7 +96,8 @@ exports[`props should render correctly 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  fill: #ffffff;
+  color: #ffffff;
+  fill: currentColor;
   height: 12px;
   width: 12px;
 }

--- a/packages/components/src/ColorControl/__tests__/__snapshots__/ColorControl.test.js.snap
+++ b/packages/components/src/ColorControl/__tests__/__snapshots__/ColorControl.test.js.snap
@@ -47,8 +47,6 @@ exports[`props should render correctly 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -106,8 +104,6 @@ exports[`props should render correctly 1`] = `
   border-color: var(--wp-g2-control-border-color-subtle);
   color: #1e1e1e;
   color: var(--wp-g2-color-text);
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   background-color: transparent;
   font-weight: normal;
   padding-left: calc(4px * 1);
@@ -208,8 +204,6 @@ exports[`props should render correctly 1`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0:focus {
   color: #1e1e1e;
   color: var(--wp-g2-color-text);
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0:focus {
@@ -227,8 +221,6 @@ exports[`props should render correctly 1`] = `
   border-color: var(--wp-g2-control-border-color-subtle);
   color: #1e1e1e;
   color: var(--wp-g2-color-text);
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0:focus {
@@ -257,8 +249,6 @@ exports[`props should render correctly 1`] = `
   background: var(--wp-g2-color-text);
   color: #ffffff;
   color: var(--wp-g2-color-text-inverted);
-  fill: #ffffff;
-  fill: var(--wp-g2-color-text-inverted);
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0[data-active='true'] {
@@ -427,7 +417,8 @@ exports[`props should render correctly 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  fill: #ffffff;
+  color: #ffffff;
+  fill: currentColor;
   height: 12px;
   width: 12px;
 }

--- a/packages/components/src/ControlGroup/__tests__/__snapshots__/ControlGroup.test.js.snap
+++ b/packages/components/src/ControlGroup/__tests__/__snapshots__/ControlGroup.test.js.snap
@@ -130,8 +130,6 @@ exports[`props should render correctly 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -423,8 +421,6 @@ exports[`props should render correctly 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -996,6 +992,8 @@ exports[`props should render mixed control types 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  color: currentColor;
+  fill: currentColor;
   height: 14px;
   width: 14px;
 }
@@ -1261,8 +1259,6 @@ exports[`props should render mixed control types 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;

--- a/packages/components/src/ExternalLink/__tests__/__snapshots__/ExternalLink.test.js.snap
+++ b/packages/components/src/ExternalLink/__tests__/__snapshots__/ExternalLink.test.js.snap
@@ -54,6 +54,7 @@ exports[`props should render correctly 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  color: currentColor;
   fill: currentColor;
   height: 15;
   width: 15;

--- a/packages/components/src/HelpTip/HelpTip.js
+++ b/packages/components/src/HelpTip/HelpTip.js
@@ -1,4 +1,4 @@
-import { help as helpIcon } from '@wordpress/i18n';
+import { help as helpIcon } from '@wordpress/icons';
 import { contextConnect, useContextSystem } from '@wp-g2/context';
 import { css, ui } from '@wp-g2/styles';
 import React from 'react';
@@ -33,10 +33,6 @@ function HelpTip(props, forwardedRef) {
 					css={css`
 						display: inline-flex;
 						opacity: 0.5;
-
-						path {
-							fill: none;
-						}
 					`}
 					fill={ui.get('colorText')}
 					icon={helpIcon}

--- a/packages/components/src/HelpTip/__tests__/__snapshots__/HelpTip.test.js.snap
+++ b/packages/components/src/HelpTip/__tests__/__snapshots__/HelpTip.test.js.snap
@@ -30,11 +30,74 @@ exports[`props should render correctly 1`] = `
   transition: none!important;
 }
 
+.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  margin: 0;
+  display: block;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  color: #1e1e1e;
+  color: var(--wp-g2-color-text);
+  fill: currentColor;
+  height: 14px;
+  width: 14px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  opacity: 0.5;
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1 {
+  -webkit-transition: none!important;
+  transition: none!important;
+}
+
+.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1 svg {
+  display: block;
+}
+
 <span
   aria-describedby="help-tip"
   class="emotion-0"
   tabindex="0"
-/>
+>
+  <div
+    class="components-icon wp-components-icon emotion-1"
+    data-g2-c16t="true"
+    data-g2-component="Icon"
+  >
+    <svg
+      aria-hidden="true"
+      focusable="false"
+      height="14"
+      role="img"
+      size="14"
+      viewBox="0 0 24 24"
+      width="14"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12 4.75a7.25 7.25 0 100 14.5 7.25 7.25 0 000-14.5zM3.25 12a8.75 8.75 0 1117.5 0 8.75 8.75 0 01-17.5 0zM12 8.75a1.5 1.5 0 01.167 2.99c-.465.052-.917.44-.917 1.01V14h1.5v-.845A3 3 0 109 10.25h1.5a1.5 1.5 0 011.5-1.5zM11.25 15v1.5h1.5V15h-1.5z"
+      />
+    </svg>
+  </div>
+</span>
 `;
 
 exports[`props should render iconSize 1`] = `
@@ -67,9 +130,72 @@ exports[`props should render iconSize 1`] = `
   transition: none!important;
 }
 
+.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  margin: 0;
+  display: block;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  color: #1e1e1e;
+  color: var(--wp-g2-color-text);
+  fill: currentColor;
+  height: 13px;
+  width: 13px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  opacity: 0.5;
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1 {
+  -webkit-transition: none!important;
+  transition: none!important;
+}
+
+.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1 svg {
+  display: block;
+}
+
 <span
   aria-describedby="help-tip"
   class="emotion-0"
   tabindex="0"
-/>
+>
+  <div
+    class="components-icon wp-components-icon emotion-1"
+    data-g2-c16t="true"
+    data-g2-component="Icon"
+  >
+    <svg
+      aria-hidden="true"
+      focusable="false"
+      height="13"
+      role="img"
+      size="13"
+      viewBox="0 0 24 24"
+      width="13"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12 4.75a7.25 7.25 0 100 14.5 7.25 7.25 0 000-14.5zM3.25 12a8.75 8.75 0 1117.5 0 8.75 8.75 0 01-17.5 0zM12 8.75a1.5 1.5 0 01.167 2.99c-.465.052-.917.44-.917 1.01V14h1.5v-.845A3 3 0 109 10.25h1.5a1.5 1.5 0 011.5-1.5zM11.25 15v1.5h1.5V15h-1.5z"
+      />
+    </svg>
+  </div>
+</span>
 `;

--- a/packages/components/src/Icon/Icon.js
+++ b/packages/components/src/Icon/Icon.js
@@ -9,7 +9,7 @@ function Icon(props, forwardedRef) {
 	const {
 		children,
 		className,
-		fill, // https://github.com/ItsJonQ/g2/pull/133#discussion_r525538497
+		fill = 'currentColor', // https://github.com/ItsJonQ/g2/pull/133#discussion_r525538497
 		height,
 		icon,
 		inline,
@@ -22,8 +22,10 @@ function Icon(props, forwardedRef) {
 	const classes = useMemo(() => {
 		const sx = {};
 
+		// https://github.com/ItsJonQ/g2/issues/136
 		sx.fill = css({
-			fill,
+			color: fill,
+			fill: 'currentColor',
 		});
 
 		sx.size = css({

--- a/packages/components/src/Icon/__tests__/__snapshots__/Icon.test.js.snap
+++ b/packages/components/src/Icon/__tests__/__snapshots__/Icon.test.js.snap
@@ -15,6 +15,8 @@ exports[`props should render correctly 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  color: currentColor;
+  fill: currentColor;
   height: 20px;
   width: 20px;
 }
@@ -59,7 +61,8 @@ exports[`props should render fill 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  fill: red;
+  color: red;
+  fill: currentColor;
   height: 20px;
   width: 20px;
 }
@@ -104,6 +107,8 @@ exports[`props should render size 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  color: currentColor;
+  fill: currentColor;
   height: 31px;
   width: 31px;
 }

--- a/packages/components/src/Popover/__tests__/__snapshots__/Popover.test.js.snap
+++ b/packages/components/src/Popover/__tests__/__snapshots__/Popover.test.js.snap
@@ -47,8 +47,6 @@ exports[`props should render correctly 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -334,8 +332,6 @@ exports[`props should render gutter 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -621,8 +617,6 @@ exports[`props should render label 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -908,8 +902,6 @@ exports[`props should render maxWidth 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -1195,8 +1187,6 @@ exports[`props should render placement 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -1482,8 +1472,6 @@ exports[`props should render visible 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -1769,8 +1757,6 @@ exports[`props should render without animation 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -2056,8 +2042,6 @@ exports[`props should render without content 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -2343,8 +2327,6 @@ exports[`props should render without modal 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;

--- a/packages/components/src/SearchInput/__tests__/__snapshots__/SearchInput.test.js.snap
+++ b/packages/components/src/SearchInput/__tests__/__snapshots__/SearchInput.test.js.snap
@@ -198,6 +198,8 @@ exports[`props should render correctly 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  color: currentColor;
+  fill: currentColor;
   height: 12px;
   width: 12px;
 }
@@ -357,8 +359,6 @@ exports[`props should render correctly 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -561,6 +561,8 @@ exports[`props should render correctly 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  color: currentColor;
+  fill: currentColor;
   height: 10px;
   width: 10px;
 }
@@ -1231,8 +1233,6 @@ exports[`props should render isLoading 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -1435,6 +1435,8 @@ exports[`props should render isLoading 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  color: currentColor;
+  fill: currentColor;
   height: 10px;
   width: 10px;
 }
@@ -1831,6 +1833,8 @@ exports[`props should render placeholder 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  color: currentColor;
+  fill: currentColor;
   height: 12px;
   width: 12px;
 }
@@ -1990,8 +1994,6 @@ exports[`props should render placeholder 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -2194,6 +2196,8 @@ exports[`props should render placeholder 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  color: currentColor;
+  fill: currentColor;
   height: 10px;
   width: 10px;
 }
@@ -2562,6 +2566,8 @@ exports[`props should render prefix 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  color: currentColor;
+  fill: currentColor;
   height: 12px;
   width: 12px;
 }
@@ -2721,8 +2727,6 @@ exports[`props should render prefix 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -2925,6 +2929,8 @@ exports[`props should render prefix 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  color: currentColor;
+  fill: currentColor;
   height: 10px;
   width: 10px;
 }
@@ -3296,6 +3302,8 @@ exports[`props should render suffix 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  color: currentColor;
+  fill: currentColor;
   height: 12px;
   width: 12px;
 }
@@ -3455,8 +3463,6 @@ exports[`props should render suffix 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -3659,6 +3665,8 @@ exports[`props should render suffix 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  color: currentColor;
+  fill: currentColor;
   height: 10px;
   width: 10px;
 }
@@ -4030,6 +4038,8 @@ exports[`props should render value 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  color: currentColor;
+  fill: currentColor;
   height: 12px;
   width: 12px;
 }
@@ -4189,8 +4199,6 @@ exports[`props should render value 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -4393,6 +4401,8 @@ exports[`props should render value 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  color: currentColor;
+  fill: currentColor;
   height: 10px;
   width: 10px;
 }

--- a/packages/components/src/Select/__tests__/__snapshots__/Select.test.js.snap
+++ b/packages/components/src/Select/__tests__/__snapshots__/Select.test.js.snap
@@ -284,6 +284,8 @@ exports[`props should render children 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  color: currentColor;
+  fill: currentColor;
   height: 14px;
   width: 14px;
 }
@@ -644,6 +646,8 @@ exports[`props should render correctly 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  color: currentColor;
+  fill: currentColor;
   height: 14px;
   width: 14px;
 }
@@ -1005,6 +1009,8 @@ exports[`props should render disabled 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  color: currentColor;
+  fill: currentColor;
   height: 14px;
   width: 14px;
 }
@@ -1368,6 +1374,8 @@ exports[`props should render readOnly 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  color: currentColor;
+  fill: currentColor;
   height: 14px;
   width: 14px;
 }
@@ -1730,6 +1738,8 @@ exports[`props should render required 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  color: currentColor;
+  fill: currentColor;
   height: 14px;
   width: 14px;
 }
@@ -2098,6 +2108,8 @@ exports[`props should render size 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  color: currentColor;
+  fill: currentColor;
   height: 14px;
   width: 14px;
 }

--- a/packages/components/src/Stepper/__tests__/__snapshots__/Stepper.test.js.snap
+++ b/packages/components/src/Stepper/__tests__/__snapshots__/Stepper.test.js.snap
@@ -139,8 +139,6 @@ exports[`props should render correctly 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -302,8 +300,6 @@ exports[`props should render correctly 1`] = `
 .emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2:focus {
   color: #1e1e1e;
   color: var(--wp-g2-color-text);
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
 }
 
 .emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2:focus {
@@ -366,6 +362,8 @@ exports[`props should render correctly 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  color: currentColor;
+  fill: currentColor;
   height: 14px;
   width: 14px;
 }
@@ -510,8 +508,6 @@ exports[`props should render correctly 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -673,8 +669,6 @@ exports[`props should render correctly 1`] = `
 .emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7:focus {
   color: #1e1e1e;
   color: var(--wp-g2-color-text);
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
 }
 
 .emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7:focus {
@@ -930,8 +924,6 @@ exports[`props should render size 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -1104,8 +1096,6 @@ exports[`props should render size 1`] = `
 .emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2:focus {
   color: #1e1e1e;
   color: var(--wp-g2-color-text);
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
 }
 
 .emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2:focus {
@@ -1168,6 +1158,8 @@ exports[`props should render size 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  color: currentColor;
+  fill: currentColor;
   height: 14px;
   width: 14px;
 }
@@ -1312,8 +1304,6 @@ exports[`props should render size 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -1486,8 +1476,6 @@ exports[`props should render size 1`] = `
 .emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7:focus {
   color: #1e1e1e;
   color: var(--wp-g2-color-text);
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
 }
 
 .emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7:focus {
@@ -1738,8 +1726,6 @@ exports[`props should render vertically 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -1908,8 +1894,6 @@ exports[`props should render vertically 1`] = `
 .emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2:focus {
   color: #1e1e1e;
   color: var(--wp-g2-color-text);
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
 }
 
 .emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2:focus {
@@ -1972,6 +1956,8 @@ exports[`props should render vertically 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  color: currentColor;
+  fill: currentColor;
   height: 14px;
   width: 14px;
 }
@@ -2116,8 +2102,6 @@ exports[`props should render vertically 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -2286,8 +2270,6 @@ exports[`props should render vertically 1`] = `
 .emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7:focus {
   color: #1e1e1e;
   color: var(--wp-g2-color-text);
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
 }
 
 .emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7:focus {

--- a/packages/components/src/Tag/__tests__/__snapshots__/Tag.test.js.snap
+++ b/packages/components/src/Tag/__tests__/__snapshots__/Tag.test.js.snap
@@ -647,8 +647,6 @@ exports[`props should render removeButtonText 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -700,12 +698,9 @@ exports[`props should render removeButtonText 1`] = `
   border-color: var(--wp-g2-control-border-color-subtle);
   color: #1e1e1e;
   color: var(--wp-g2-color-text);
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   padding: calc(4px * 0);
   padding: calc(var(--wp-g2-grid-base) * 0);
   color: currentColor;
-  fill: currentColor;
 }
 
 .emotion-3.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3>*+*:not(marquee) {
@@ -807,8 +802,6 @@ exports[`props should render removeButtonText 1`] = `
   border-color: var(--wp-g2-control-border-color-subtle);
   color: #1e1e1e;
   color: var(--wp-g2-color-text);
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
 }
 
 .emotion-3.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3:focus {
@@ -819,7 +812,6 @@ exports[`props should render removeButtonText 1`] = `
 .emotion-3.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3:hover,
 .emotion-3.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3:focus {
   color: currentColor;
-  fill: currentColor;
 }
 
 .emotion-4.emotion-4.emotion-4.emotion-4.emotion-4.emotion-4.emotion-4 {
@@ -874,6 +866,8 @@ exports[`props should render removeButtonText 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  color: currentColor;
+  fill: currentColor;
   height: 12px;
   width: 12px;
 }

--- a/packages/components/src/Tooltip/__tests__/__snapshots__/Tooltip.test.js.snap
+++ b/packages/components/src/Tooltip/__tests__/__snapshots__/Tooltip.test.js.snap
@@ -47,8 +47,6 @@ exports[`props should render animatedDuration 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -333,8 +331,6 @@ exports[`props should render correctly 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -619,8 +615,6 @@ exports[`props should render gutter 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -905,8 +899,6 @@ exports[`props should render placement 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -1191,8 +1183,6 @@ exports[`props should render visible 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -1477,8 +1467,6 @@ exports[`props should render without animation 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -1765,8 +1753,6 @@ exports[`props should render without content 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -2051,8 +2037,6 @@ exports[`props should render without modal 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;

--- a/packages/components/src/__tests__/__snapshots__/Components.test.js.snap
+++ b/packages/components/src/__tests__/__snapshots__/Components.test.js.snap
@@ -1670,6 +1670,8 @@ exports[`props should render ArrowIndicator 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  color: currentColor;
+  fill: currentColor;
   height: 5px;
   width: 5px;
 }
@@ -1809,6 +1811,8 @@ exports[`props should render ArrowIndicator with css prop 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  color: currentColor;
+  fill: currentColor;
   height: 5px;
   width: 5px;
 }
@@ -1950,6 +1954,8 @@ exports[`props should render ArrowIndicator with css prop 2`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  color: currentColor;
+  fill: currentColor;
   height: 5px;
   width: 5px;
 }
@@ -2830,8 +2836,6 @@ exports[`props should render BaseButton 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -3006,8 +3010,6 @@ exports[`props should render BaseButton with css prop 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -3182,8 +3184,6 @@ exports[`props should render BaseButton with css prop 2`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -3681,8 +3681,6 @@ exports[`props should render Button 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -3923,8 +3921,6 @@ exports[`props should render Button with css prop 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -4165,8 +4161,6 @@ exports[`props should render Button with css prop 2`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -6027,6 +6021,8 @@ input:checked+.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emoti
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  color: currentColor;
+  fill: currentColor;
   height: 12px;
   width: 12px;
 }
@@ -6271,8 +6267,6 @@ exports[`props should render ClipboardButton 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -6513,8 +6507,6 @@ exports[`props should render ClipboardButton with css prop 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -6755,8 +6747,6 @@ exports[`props should render ClipboardButton with css prop 2`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -6999,8 +6989,6 @@ exports[`props should render CloseButton 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -7046,8 +7034,6 @@ exports[`props should render CloseButton 1`] = `
   border-color: var(--wp-g2-control-border-color-subtle);
   color: #1e1e1e;
   color: var(--wp-g2-color-text);
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   padding: calc(4px * 0);
   padding: calc(var(--wp-g2-grid-base) * 0);
 }
@@ -7146,8 +7132,6 @@ exports[`props should render CloseButton 1`] = `
   border-color: var(--wp-g2-control-border-color-subtle);
   color: #1e1e1e;
   color: var(--wp-g2-color-text);
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0:focus {
@@ -7207,6 +7191,8 @@ exports[`props should render CloseButton 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  color: currentColor;
+  fill: currentColor;
   height: 12px;
   width: 12px;
 }
@@ -7361,8 +7347,6 @@ exports[`props should render CloseButton with css prop 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -7408,8 +7392,6 @@ exports[`props should render CloseButton with css prop 1`] = `
   border-color: var(--wp-g2-control-border-color-subtle);
   color: #1e1e1e;
   color: var(--wp-g2-color-text);
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   padding: calc(4px * 0);
   padding: calc(var(--wp-g2-grid-base) * 0);
 }
@@ -7508,8 +7490,6 @@ exports[`props should render CloseButton with css prop 1`] = `
   border-color: var(--wp-g2-control-border-color-subtle);
   color: #1e1e1e;
   color: var(--wp-g2-color-text);
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0:focus {
@@ -7569,6 +7549,8 @@ exports[`props should render CloseButton with css prop 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  color: currentColor;
+  fill: currentColor;
   height: 12px;
   width: 12px;
 }
@@ -7723,8 +7705,6 @@ exports[`props should render CloseButton with css prop 2`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -7770,8 +7750,6 @@ exports[`props should render CloseButton with css prop 2`] = `
   border-color: var(--wp-g2-control-border-color-subtle);
   color: #1e1e1e;
   color: var(--wp-g2-color-text);
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   padding: calc(4px * 0);
   padding: calc(var(--wp-g2-grid-base) * 0);
   background: red;
@@ -7872,8 +7850,6 @@ exports[`props should render CloseButton with css prop 2`] = `
   border-color: var(--wp-g2-control-border-color-subtle);
   color: #1e1e1e;
   color: var(--wp-g2-color-text);
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0:focus {
@@ -7933,6 +7909,8 @@ exports[`props should render CloseButton with css prop 2`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  color: currentColor;
+  fill: currentColor;
   height: 12px;
   width: 12px;
 }
@@ -8136,7 +8114,8 @@ exports[`props should render ColorCircle 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  fill: #ffffff;
+  color: #ffffff;
+  fill: currentColor;
   height: 12px;
   width: 12px;
 }
@@ -8290,7 +8269,8 @@ exports[`props should render ColorCircle with css prop 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  fill: #ffffff;
+  color: #ffffff;
+  fill: currentColor;
   height: 12px;
   width: 12px;
 }
@@ -8446,7 +8426,8 @@ exports[`props should render ColorCircle with css prop 2`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  fill: #ffffff;
+  color: #ffffff;
+  fill: currentColor;
   height: 12px;
   width: 12px;
 }
@@ -8551,8 +8532,6 @@ exports[`props should render ColorControl 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -8610,8 +8589,6 @@ exports[`props should render ColorControl 1`] = `
   border-color: var(--wp-g2-control-border-color-subtle);
   color: #1e1e1e;
   color: var(--wp-g2-color-text);
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   background-color: transparent;
   font-weight: normal;
   padding-left: calc(4px * 1);
@@ -8712,8 +8689,6 @@ exports[`props should render ColorControl 1`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0:focus {
   color: #1e1e1e;
   color: var(--wp-g2-color-text);
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0:focus {
@@ -8731,8 +8706,6 @@ exports[`props should render ColorControl 1`] = `
   border-color: var(--wp-g2-control-border-color-subtle);
   color: #1e1e1e;
   color: var(--wp-g2-color-text);
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0:focus {
@@ -8761,8 +8734,6 @@ exports[`props should render ColorControl 1`] = `
   background: var(--wp-g2-color-text);
   color: #ffffff;
   color: var(--wp-g2-color-text-inverted);
-  fill: #ffffff;
-  fill: var(--wp-g2-color-text-inverted);
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0[data-active='true'] {
@@ -8931,7 +8902,8 @@ exports[`props should render ColorControl 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  fill: #ffffff;
+  color: #ffffff;
+  fill: currentColor;
   height: 12px;
   width: 12px;
 }
@@ -9100,8 +9072,6 @@ exports[`props should render ColorControl with css prop 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -9159,8 +9129,6 @@ exports[`props should render ColorControl with css prop 1`] = `
   border-color: var(--wp-g2-control-border-color-subtle);
   color: #1e1e1e;
   color: var(--wp-g2-color-text);
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   background-color: transparent;
   font-weight: normal;
   padding-left: calc(4px * 1);
@@ -9261,8 +9229,6 @@ exports[`props should render ColorControl with css prop 1`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0:focus {
   color: #1e1e1e;
   color: var(--wp-g2-color-text);
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0:focus {
@@ -9280,8 +9246,6 @@ exports[`props should render ColorControl with css prop 1`] = `
   border-color: var(--wp-g2-control-border-color-subtle);
   color: #1e1e1e;
   color: var(--wp-g2-color-text);
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0:focus {
@@ -9310,8 +9274,6 @@ exports[`props should render ColorControl with css prop 1`] = `
   background: var(--wp-g2-color-text);
   color: #ffffff;
   color: var(--wp-g2-color-text-inverted);
-  fill: #ffffff;
-  fill: var(--wp-g2-color-text-inverted);
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0[data-active='true'] {
@@ -9480,7 +9442,8 @@ exports[`props should render ColorControl with css prop 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  fill: #ffffff;
+  color: #ffffff;
+  fill: currentColor;
   height: 12px;
   width: 12px;
 }
@@ -9649,8 +9612,6 @@ exports[`props should render ColorControl with css prop 2`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -9708,8 +9669,6 @@ exports[`props should render ColorControl with css prop 2`] = `
   border-color: var(--wp-g2-control-border-color-subtle);
   color: #1e1e1e;
   color: var(--wp-g2-color-text);
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   background-color: transparent;
   font-weight: normal;
   padding-left: calc(4px * 1);
@@ -9812,8 +9771,6 @@ exports[`props should render ColorControl with css prop 2`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0:focus {
   color: #1e1e1e;
   color: var(--wp-g2-color-text);
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0:focus {
@@ -9831,8 +9788,6 @@ exports[`props should render ColorControl with css prop 2`] = `
   border-color: var(--wp-g2-control-border-color-subtle);
   color: #1e1e1e;
   color: var(--wp-g2-color-text);
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0:focus {
@@ -9861,8 +9816,6 @@ exports[`props should render ColorControl with css prop 2`] = `
   background: var(--wp-g2-color-text);
   color: #ffffff;
   color: var(--wp-g2-color-text-inverted);
-  fill: #ffffff;
-  fill: var(--wp-g2-color-text-inverted);
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0[data-active='true'] {
@@ -10031,7 +9984,8 @@ exports[`props should render ColorControl with css prop 2`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  fill: #ffffff;
+  color: #ffffff;
+  fill: currentColor;
   height: 12px;
   width: 12px;
 }
@@ -11402,8 +11356,6 @@ exports[`props should render DropdownMenuItem 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -11696,8 +11648,6 @@ exports[`props should render DropdownMenuItem with css prop 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -11990,8 +11940,6 @@ exports[`props should render DropdownMenuItem with css prop 2`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -12278,8 +12226,6 @@ exports[`props should render DropdownTrigger 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -12520,8 +12466,6 @@ exports[`props should render DropdownTrigger with css prop 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -12762,8 +12706,6 @@ exports[`props should render DropdownTrigger with css prop 2`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -13165,6 +13107,7 @@ exports[`props should render ExternalLink 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  color: currentColor;
   fill: currentColor;
   height: 15;
   width: 15;
@@ -13282,6 +13225,7 @@ exports[`props should render ExternalLink with css prop 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  color: currentColor;
   fill: currentColor;
   height: 15;
   width: 15;
@@ -13401,6 +13345,7 @@ exports[`props should render ExternalLink with css prop 2`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  color: currentColor;
   fill: currentColor;
   height: 15;
   width: 15;
@@ -14441,11 +14386,74 @@ exports[`props should render HelpTip 1`] = `
   transition: none!important;
 }
 
+.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  margin: 0;
+  display: block;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  color: #1e1e1e;
+  color: var(--wp-g2-color-text);
+  fill: currentColor;
+  height: 14px;
+  width: 14px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  opacity: 0.5;
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1 {
+  -webkit-transition: none!important;
+  transition: none!important;
+}
+
+.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1 svg {
+  display: block;
+}
+
 <span
   aria-describedby="HelpTip"
   class="emotion-0"
   tabindex="0"
-/>
+>
+  <div
+    class="components-icon wp-components-icon emotion-1"
+    data-g2-c16t="true"
+    data-g2-component="Icon"
+  >
+    <svg
+      aria-hidden="true"
+      focusable="false"
+      height="14"
+      role="img"
+      size="14"
+      viewBox="0 0 24 24"
+      width="14"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12 4.75a7.25 7.25 0 100 14.5 7.25 7.25 0 000-14.5zM3.25 12a8.75 8.75 0 1117.5 0 8.75 8.75 0 01-17.5 0zM12 8.75a1.5 1.5 0 01.167 2.99c-.465.052-.917.44-.917 1.01V14h1.5v-.845A3 3 0 109 10.25h1.5a1.5 1.5 0 011.5-1.5zM11.25 15v1.5h1.5V15h-1.5z"
+      />
+    </svg>
+  </div>
+</span>
 `;
 
 exports[`props should render Icon 1`] = `null`;
@@ -16159,8 +16167,6 @@ exports[`props should render MenuItem 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -16453,8 +16459,6 @@ exports[`props should render MenuItem with css prop 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -16747,8 +16751,6 @@ exports[`props should render MenuItem with css prop 2`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -17653,8 +17655,6 @@ exports[`props should render ModalHeader 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -18027,8 +18027,6 @@ exports[`props should render ModalHeader with css prop 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -18403,8 +18401,6 @@ exports[`props should render ModalHeader with css prop 2`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -18671,8 +18667,6 @@ exports[`props should render ModalTrigger 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -18915,8 +18909,6 @@ exports[`props should render NavigatorButton 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -19157,8 +19149,6 @@ exports[`props should render NavigatorButton with css prop 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -19399,8 +19389,6 @@ exports[`props should render NavigatorButton with css prop 2`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -20642,6 +20630,8 @@ exports[`props should render SearchInput 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  color: currentColor;
+  fill: currentColor;
   height: 12px;
   width: 12px;
 }
@@ -20801,8 +20791,6 @@ exports[`props should render SearchInput 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -21005,6 +20993,8 @@ exports[`props should render SearchInput 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  color: currentColor;
+  fill: currentColor;
   height: 10px;
   width: 10px;
 }
@@ -21830,6 +21820,8 @@ exports[`props should render Select 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  color: currentColor;
+  fill: currentColor;
   height: 14px;
   width: 14px;
 }
@@ -23483,8 +23475,6 @@ exports[`props should render Stepper 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -23646,8 +23636,6 @@ exports[`props should render Stepper 1`] = `
 .emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2:focus {
   color: #1e1e1e;
   color: var(--wp-g2-color-text);
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
 }
 
 .emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2:focus {
@@ -23710,6 +23698,8 @@ exports[`props should render Stepper 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  color: currentColor;
+  fill: currentColor;
   height: 14px;
   width: 14px;
 }
@@ -23854,8 +23844,6 @@ exports[`props should render Stepper 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -24017,8 +24005,6 @@ exports[`props should render Stepper 1`] = `
 .emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7:focus {
   color: #1e1e1e;
   color: var(--wp-g2-color-text);
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
 }
 
 .emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7:focus {
@@ -24275,8 +24261,6 @@ exports[`props should render Stepper with css prop 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -24438,8 +24422,6 @@ exports[`props should render Stepper with css prop 1`] = `
 .emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2:focus {
   color: #1e1e1e;
   color: var(--wp-g2-color-text);
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
 }
 
 .emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2:focus {
@@ -24502,6 +24484,8 @@ exports[`props should render Stepper with css prop 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  color: currentColor;
+  fill: currentColor;
   height: 14px;
   width: 14px;
 }
@@ -24646,8 +24630,6 @@ exports[`props should render Stepper with css prop 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -24809,8 +24791,6 @@ exports[`props should render Stepper with css prop 1`] = `
 .emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7:focus {
   color: #1e1e1e;
   color: var(--wp-g2-color-text);
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
 }
 
 .emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7:focus {
@@ -25069,8 +25049,6 @@ exports[`props should render Stepper with css prop 2`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -25232,8 +25210,6 @@ exports[`props should render Stepper with css prop 2`] = `
 .emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2:focus {
   color: #1e1e1e;
   color: var(--wp-g2-color-text);
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
 }
 
 .emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2:focus {
@@ -25296,6 +25272,8 @@ exports[`props should render Stepper with css prop 2`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  color: currentColor;
+  fill: currentColor;
   height: 14px;
   width: 14px;
 }
@@ -25440,8 +25418,6 @@ exports[`props should render Stepper with css prop 2`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
   line-height: 1;
@@ -25603,8 +25579,6 @@ exports[`props should render Stepper with css prop 2`] = `
 .emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7:focus {
   color: #1e1e1e;
   color: var(--wp-g2-color-text);
-  fill: #1e1e1e;
-  fill: var(--wp-g2-color-text);
 }
 
 .emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7:focus {


### PR DESCRIPTION
This update improves how the `Icon` component handles the `fill` rendering for `@wordpress/icons` svgs. 

This idea came from the recent `Icon` component + package refactor,
https://github.com/ItsJonQ/g2/pull/133/files/eb4a8c7ff3e643569bd26a2f62516c9ea99258e3#r525559793

Because `@wordpress/components` uses `fill` for it's Icon colors (vs. `color` from `react-icons`), we needed to add the `fill` CSS property to various styles (e.g. `BaseButton`) to accommodate this.

### Problem

I can imagine this not scaling well, as components (G2 or not) may need to adjust icon color from a higher node vs. direct manipulation through `<Icon fill="red" />`. In the case of `Button`, by default, we want the `Icon` to absorb the (text) color from the `Button`.

### Solution

I think we can do this for `Icon.js`

```jsx
		sx.fill = css({
			color: fill,
			fill: 'currentColor',
		});
```

We're still passing in the `fill` prop into `<Icon fill="red" />`. However, the `Icon` will use that for the `color` CSS prop instead, and `fill` will absorb it through `currentColor`.

Here's a quick test of this solution working:

<img width="490" alt="Screen Shot 2020-11-17 at 5 24 00 PM" src="https://user-images.githubusercontent.com/2322354/99457953-c7dc3f80-28f9-11eb-831b-9c0b74e58137.png">

I've removed the recently added `fill` styles in `BaseButton` and used the `currentColor` strategy above.
We can see that the `X` close icons are correctly absorbing the colors for the `Alert`.

---

Resolves https://github.com/ItsJonQ/g2/issues/136