### PR TITLE
Dropdown: Enable custom state and children render function handling

### DIFF
--- a/packages/components/src/Dropdown/Dropdown.js
+++ b/packages/components/src/Dropdown/Dropdown.js
@@ -1,4 +1,5 @@
 import { contextConnect, useContextSystem } from '@wp-g2/context';
+import { renderChildren } from '@wp-g2/utils';
 import React, { useMemo } from 'react';
 import { useMenuState } from 'reakit';
 
@@ -16,11 +17,12 @@ function Dropdown(props, forwardedRef) {
 		label,
 		modal = true,
 		placement,
+		state,
 		visible,
 		...otherProps
 	} = useContextSystem(props, 'Dropdown');
 
-	const menu = useMenuState({
+	const _menu = useMenuState({
 		animated: animated ? animationDuration : undefined,
 		baseId: baseId || id,
 		gutter,
@@ -29,6 +31,8 @@ function Dropdown(props, forwardedRef) {
 		visible,
 		...otherProps,
 	});
+
+	const menu = state || _menu;
 
 	const contextProps = useMemo(() => {
 		const uniqueId = `dropdown-${menu.baseId}`;
@@ -43,9 +47,21 @@ function Dropdown(props, forwardedRef) {
 
 	return (
 		<DropdownContext.Provider ref={forwardedRef} value={contextProps}>
-			{children}
+			{renderChildren(children, mapMenuStateToProps(menu))}
 		</DropdownContext.Provider>
 	);
+}
+
+/**
+ * Remap Reakit's menuState for `@wordpress/components` current Dropdown/
+ * DropdownMenu API.
+ *
+ * @see
+ * https://github.com/WordPress/gutenberg/tree/master/packages/components/src/dropdown-menu
+ */
+function mapMenuStateToProps(state) {
+	const { hide, toggle, visible } = state;
+	return { ...state, isOpen: visible, onToggle: toggle, onClose: hide };
 }
 
 export default contextConnect(Dropdown, 'Dropdown');

--- a/packages/components/src/Dropdown/__stories__/Dropdown.stories.js
+++ b/packages/components/src/Dropdown/__stories__/Dropdown.stories.js
@@ -68,3 +68,24 @@ export const _default = () => {
 		</Dropdown>
 	);
 };
+
+export const _renderFunction = () => {
+	return (
+		<Dropdown visible>
+			{({ onClose }) => {
+				return (
+					<>
+						<DropdownTrigger>Dropdown</DropdownTrigger>
+						<DropdownMenu>
+							<DropdownMenuItem onClick={onClose}>
+								One
+							</DropdownMenuItem>
+							<DropdownMenuItem>Two</DropdownMenuItem>
+							<DropdownMenuItem>Three</DropdownMenuItem>
+						</DropdownMenu>
+					</>
+				);
+			}}
+		</Dropdown>
+	);
+};

--- a/packages/components/src/__stories__/WIP/ListGroups.stories.js
+++ b/packages/components/src/__stories__/WIP/ListGroups.stories.js
@@ -116,13 +116,14 @@ const SpacingVisualizer = ({ children, visualize }) => {
 	return <SpacingVisualizerView>{children}</SpacingVisualizerView>;
 };
 
-const BaseGridItem = ({ children, ...props }) => {
+const BaseGridItem = ({ children, ...props }, forwardedRef) => {
 	return (
 		<Surface
 			border
 			css={[ui.frame.height('100%'), ui.padding(4)]}
 			variant="tertiary"
 			{...props}
+			ref={forwardedRef}
 		>
 			<Container width={300}>{children}</Container>
 		</Surface>

--- a/packages/utils/src/react.js
+++ b/packages/utils/src/react.js
@@ -48,3 +48,16 @@ export function getDisplayName(tagName) {
 
 	return displayName;
 }
+
+export function isRenderProp(children) {
+	return is.function(children);
+}
+
+export function renderChildren(children, props = {}) {
+	if (isRenderProp(children)) {
+		const { children: _, ...rest } = props;
+		return children(rest);
+	}
+
+	return children;
+}


### PR DESCRIPTION
This update improves the `Dropdown` component to accept a custom Reakit (menu) state. It also now accommodates render function handling from the `children` prop.

##### Example

```jsx
<Dropdown visible>
  {({ onClose }) => {
    return (
      <>
        <DropdownTrigger>Dropdown</DropdownTrigger>
        <DropdownMenu>
          <DropdownMenuItem onClick={onClose}>
            One
          </DropdownMenuItem>
          <DropdownMenuItem>Two</DropdownMenuItem>
          <DropdownMenuItem>Three</DropdownMenuItem>
        </DropdownMenu>
      </>
    );
  }}
</Dropdown>
```

The callbacks props being passed to the `children` render prop is remapped (`useMenuState`) to support current `@wordpress/components` Dropdown/DropdownMenu APIs:

https://github.com/WordPress/gutenberg/tree/master/packages/components/src/dropdown-menu

---

Resolves: https://github.com/ItsJonQ/g2/issues/147