### PR TITLE
FontSizeControl: Fix Button height + Custom value

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
 	"packages": ["packages/*"],
-	"version": "0.0.108",
+	"version": "0.0.109-alpha.0",
 	"npmClient": "yarn",
 	"useWorkspaces": true,
 	"registry": "https://registry.npmjs.org/"

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wp-g2/components",
-  "version": "0.0.108",
+  "version": "0.0.109-alpha.0",
   "description": "React components for G2 Components.",
   "main": "dist/cjs/index.js",
   "module": "dist/es/index.js",

--- a/packages/components/src/Alert/__tests__/__snapshots__/Alert.test.js.snap
+++ b/packages/components/src/Alert/__tests__/__snapshots__/Alert.test.js.snap
@@ -252,6 +252,7 @@ exports[`props should render as dismissable 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -1035,6 +1036,7 @@ exports[`props should render with status 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);

--- a/packages/components/src/BaseButton/BaseButton.styles.js
+++ b/packages/components/src/BaseButton/BaseButton.styles.js
@@ -14,6 +14,7 @@ export const Button = css`
 	cursor: pointer;
 	display: inline-flex;
 	font-size: ${ui.get('fontSize')};
+	height: auto;
 	line-height: 1;
 	min-height: ${ui.get('controlHeight')};
 	outline: none;

--- a/packages/components/src/BaseButton/__tests__/__snapshots__/BaseButton.test.js.snap
+++ b/packages/components/src/BaseButton/__tests__/__snapshots__/BaseButton.test.js.snap
@@ -49,6 +49,7 @@ exports[`props should render correctly 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);

--- a/packages/components/src/Button/__tests__/__snapshots__/Button.test.js.snap
+++ b/packages/components/src/Button/__tests__/__snapshots__/Button.test.js.snap
@@ -49,6 +49,7 @@ exports[`props should render (Flex) gap 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -335,6 +336,7 @@ exports[`props should render as link (href) 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -621,6 +623,7 @@ exports[`props should render correctly 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -907,6 +910,7 @@ exports[`props should render disabled 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -1196,6 +1200,7 @@ exports[`props should render elevation 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -1482,6 +1487,7 @@ exports[`props should render hasCaret 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -1863,6 +1869,7 @@ exports[`props should render icon 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -2236,6 +2243,7 @@ exports[`props should render isControl 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -2547,6 +2555,7 @@ exports[`props should render isDestructive 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -2835,6 +2844,7 @@ exports[`props should render isLoading 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -3455,6 +3465,7 @@ exports[`props should render isNarrow 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -3745,6 +3756,7 @@ exports[`props should render isRounded 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -4032,6 +4044,7 @@ exports[`props should render isSubtle 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -4336,6 +4349,7 @@ exports[`props should render prefix 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -4669,6 +4683,7 @@ exports[`props should render size 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -4966,6 +4981,7 @@ exports[`props should render suffix 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -5299,6 +5315,7 @@ exports[`props should render variant 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);

--- a/packages/components/src/ButtonGroup/__tests__/__snapshots__/ButtonGroup.test.js.snap
+++ b/packages/components/src/ButtonGroup/__tests__/__snapshots__/ButtonGroup.test.js.snap
@@ -76,6 +76,7 @@ exports[`props should render correctly 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);

--- a/packages/components/src/Card/__tests__/__snapshots__/Card.test.js.snap
+++ b/packages/components/src/Card/__tests__/__snapshots__/Card.test.js.snap
@@ -298,6 +298,7 @@ exports[`props should render CardInnerBody 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -1010,6 +1011,7 @@ exports[`props should render correctly 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);

--- a/packages/components/src/ClipboardButton/__tests__/__snapshots__/ClipboardButton.test.js.snap
+++ b/packages/components/src/ClipboardButton/__tests__/__snapshots__/ClipboardButton.test.js.snap
@@ -49,6 +49,7 @@ exports[`props should render correctly 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);

--- a/packages/components/src/CloseButton/__tests__/__snapshots__/CloseButton.test.js.snap
+++ b/packages/components/src/CloseButton/__tests__/__snapshots__/CloseButton.test.js.snap
@@ -49,6 +49,7 @@ exports[`props should render correctly 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -410,6 +411,7 @@ exports[`props should render size 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -778,6 +780,7 @@ exports[`props should render variant 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);

--- a/packages/components/src/Collapsible/__tests__/__snapshots__/Collapsible.test.js.snap
+++ b/packages/components/src/Collapsible/__tests__/__snapshots__/Collapsible.test.js.snap
@@ -72,6 +72,7 @@ exports[`props should render correctly 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -444,6 +445,7 @@ exports[`props should render visible 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);

--- a/packages/components/src/ColorControl/__tests__/__snapshots__/ColorControl.test.js.snap
+++ b/packages/components/src/ColorControl/__tests__/__snapshots__/ColorControl.test.js.snap
@@ -49,6 +49,7 @@ exports[`props should render correctly 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);

--- a/packages/components/src/ControlGroup/__tests__/__snapshots__/ControlGroup.test.js.snap
+++ b/packages/components/src/ControlGroup/__tests__/__snapshots__/ControlGroup.test.js.snap
@@ -106,6 +106,7 @@ exports[`props should render correctly 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -367,6 +368,7 @@ exports[`props should render correctly 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -1148,6 +1150,7 @@ exports[`props should render mixed control types 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);

--- a/packages/components/src/Popover/__tests__/__snapshots__/Popover.test.js.snap
+++ b/packages/components/src/Popover/__tests__/__snapshots__/Popover.test.js.snap
@@ -49,6 +49,7 @@ exports[`props should render correctly 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -338,6 +339,7 @@ exports[`props should render gutter 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -627,6 +629,7 @@ exports[`props should render label 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -916,6 +919,7 @@ exports[`props should render maxWidth 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -1205,6 +1209,7 @@ exports[`props should render placement 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -1494,6 +1499,7 @@ exports[`props should render visible 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -1783,6 +1789,7 @@ exports[`props should render without animation 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -2072,6 +2079,7 @@ exports[`props should render without content 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -2361,6 +2369,7 @@ exports[`props should render without modal 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);

--- a/packages/components/src/SearchInput/__tests__/__snapshots__/SearchInput.test.js.snap
+++ b/packages/components/src/SearchInput/__tests__/__snapshots__/SearchInput.test.js.snap
@@ -367,6 +367,7 @@ exports[`props should render correctly 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -1250,6 +1251,7 @@ exports[`props should render isLoading 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -2021,6 +2023,7 @@ exports[`props should render placeholder 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -2764,6 +2767,7 @@ exports[`props should render prefix 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -3510,6 +3514,7 @@ exports[`props should render suffix 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -4256,6 +4261,7 @@ exports[`props should render value 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);

--- a/packages/components/src/Stepper/__tests__/__snapshots__/Stepper.test.js.snap
+++ b/packages/components/src/Stepper/__tests__/__snapshots__/Stepper.test.js.snap
@@ -112,6 +112,7 @@ exports[`props should render correctly 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -447,6 +448,7 @@ exports[`props should render correctly 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -825,6 +827,7 @@ exports[`props should render size 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -1171,6 +1174,7 @@ exports[`props should render size 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -1555,6 +1559,7 @@ exports[`props should render vertically 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -1897,6 +1902,7 @@ exports[`props should render vertically 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);

--- a/packages/components/src/Tag/__tests__/__snapshots__/Tag.test.js.snap
+++ b/packages/components/src/Tag/__tests__/__snapshots__/Tag.test.js.snap
@@ -655,6 +655,7 @@ exports[`props should render removeButtonText 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);

--- a/packages/components/src/Tooltip/__tests__/__snapshots__/Tooltip.test.js.snap
+++ b/packages/components/src/Tooltip/__tests__/__snapshots__/Tooltip.test.js.snap
@@ -49,6 +49,7 @@ exports[`props should render animatedDuration 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -337,6 +338,7 @@ exports[`props should render correctly 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -625,6 +627,7 @@ exports[`props should render gutter 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -913,6 +916,7 @@ exports[`props should render placement 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -1201,6 +1205,7 @@ exports[`props should render visible 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -1489,6 +1494,7 @@ exports[`props should render without animation 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -1779,6 +1785,7 @@ exports[`props should render without content 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -2067,6 +2074,7 @@ exports[`props should render without modal 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);

--- a/packages/components/src/__tests__/__snapshots__/Components.test.js.snap
+++ b/packages/components/src/__tests__/__snapshots__/Components.test.js.snap
@@ -2853,6 +2853,7 @@ exports[`props should render BaseButton 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -3031,6 +3032,7 @@ exports[`props should render BaseButton with css prop 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -3209,6 +3211,7 @@ exports[`props should render BaseButton with css prop 2`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -3722,6 +3725,7 @@ exports[`props should render Button 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -3966,6 +3970,7 @@ exports[`props should render Button with css prop 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -4210,6 +4215,7 @@ exports[`props should render Button with css prop 2`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -6350,6 +6356,7 @@ exports[`props should render ClipboardButton 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -6594,6 +6601,7 @@ exports[`props should render ClipboardButton with css prop 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -6838,6 +6846,7 @@ exports[`props should render ClipboardButton with css prop 2`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -7084,6 +7093,7 @@ exports[`props should render CloseButton 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -7446,6 +7456,7 @@ exports[`props should render CloseButton with css prop 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -7808,6 +7819,7 @@ exports[`props should render CloseButton with css prop 2`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -8639,6 +8651,7 @@ exports[`props should render ColorControl 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -9182,6 +9195,7 @@ exports[`props should render ColorControl with css prop 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -9725,6 +9739,7 @@ exports[`props should render ColorControl with css prop 2`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -12072,6 +12087,7 @@ exports[`props should render DropdownMenuItem 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -12368,6 +12384,7 @@ exports[`props should render DropdownMenuItem with css prop 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -12664,6 +12681,7 @@ exports[`props should render DropdownMenuItem with css prop 2`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -12954,6 +12972,7 @@ exports[`props should render DropdownTrigger 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -13198,6 +13217,7 @@ exports[`props should render DropdownTrigger with css prop 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -13442,6 +13462,7 @@ exports[`props should render DropdownTrigger with css prop 2`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -15268,6 +15289,7 @@ exports[`props should render FontSizeControl 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -18054,6 +18076,7 @@ exports[`props should render MenuItem 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -18350,6 +18373,7 @@ exports[`props should render MenuItem with css prop 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -18646,6 +18670,7 @@ exports[`props should render MenuItem with css prop 2`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -19574,6 +19599,7 @@ exports[`props should render ModalHeader 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -19955,6 +19981,7 @@ exports[`props should render ModalHeader with css prop 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -20338,6 +20365,7 @@ exports[`props should render ModalHeader with css prop 2`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -20608,6 +20636,7 @@ exports[`props should render ModalTrigger 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -20854,6 +20883,7 @@ exports[`props should render NavigatorButton 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -21098,6 +21128,7 @@ exports[`props should render NavigatorButton with css prop 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -21342,6 +21373,7 @@ exports[`props should render NavigatorButton with css prop 2`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -22754,6 +22786,7 @@ exports[`props should render SearchInput 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -26705,6 +26738,7 @@ exports[`props should render Stepper 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -27040,6 +27074,7 @@ exports[`props should render Stepper 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -27419,6 +27454,7 @@ exports[`props should render Stepper with css prop 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -27754,6 +27790,7 @@ exports[`props should render Stepper with css prop 1`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -28135,6 +28172,7 @@ exports[`props should render Stepper with css prop 2`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);
@@ -28470,6 +28508,7 @@ exports[`props should render Stepper with css prop 2`] = `
   display: inline-flex;
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+  height: auto;
   line-height: 1;
   min-height: 30px;
   min-height: var(--wp-g2-control-height);

--- a/packages/components/src/font-size-control/font-size-control-utils.js
+++ b/packages/components/src/font-size-control/font-size-control-utils.js
@@ -22,7 +22,7 @@ function isCustomValue(values = [], value) {
 	return !!item;
 }
 
-export function isCustomSelectedItem( selectedItem ) {
+export function isCustomSelectedItem(selectedItem) {
 	return selectedItem?.key === CUSTOM_FONT_SIZE;
 }
 

--- a/packages/components/src/font-size-control/font-size-control-utils.js
+++ b/packages/components/src/font-size-control/font-size-control-utils.js
@@ -22,6 +22,10 @@ function isCustomValue(values = [], value) {
 	return !!item;
 }
 
+export function isCustomSelectedItem(selectedItem) {
+	return selectedItem?.slug === CUSTOM_FONT_SIZE;
+}
+
 export function getSelectValueFromFontSize(fontSizes, value) {
 	if (!value) return DEFAULT_FONT_SIZE;
 

--- a/packages/components/src/font-size-control/font-size-control-utils.js
+++ b/packages/components/src/font-size-control/font-size-control-utils.js
@@ -22,8 +22,8 @@ function isCustomValue(values = [], value) {
 	return !!item;
 }
 
-export function isCustomSelectedItem(selectedItem) {
-	return selectedItem?.slug === CUSTOM_FONT_SIZE;
+export function isCustomSelectedItem( selectedItem ) {
+	return selectedItem?.key === CUSTOM_FONT_SIZE;
 }
 
 export function getSelectValueFromFontSize(fontSizes, value) {

--- a/packages/components/src/font-size-control/use-font-size-control.js
+++ b/packages/components/src/font-size-control/use-font-size-control.js
@@ -10,6 +10,7 @@ import {
 	getSelectOptions,
 	getSelectValueFromFontSize,
 	hasUnit,
+	isCustomSelectedItem,
 } from './font-size-control-utils';
 
 export function useFontSizeControl(props) {
@@ -43,6 +44,8 @@ export function useFontSizeControl(props) {
 
 	const handleOnChange = React.useCallback(
 		({ selectedItem }) => {
+			if (isCustomSelectedItem(selectedItem)) return;
+
 			if (hasUnits) {
 				onChange(selectedItem.size);
 			} else {

--- a/packages/design-tools/package.json
+++ b/packages/design-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wp-g2/design-tools",
-  "version": "0.0.108",
+  "version": "0.0.109-alpha.0",
   "description": "",
   "main": "dist/cjs/index.js",
   "module": "dist/es/index.js",
@@ -16,7 +16,7 @@
   "author": "Jon Quach <hello@jonquach.com> (https://jonquach.com)",
   "license": "MIT",
   "dependencies": {
-    "@wp-g2/components": "^0.0.108",
+    "@wp-g2/components": "^0.0.109-alpha.0",
     "@wp-g2/icons": "^0.0.108",
     "@wp-g2/protokit": "^0.0.108",
     "@wp-g2/styles": "^0.0.108",

--- a/packages/hint/package.json
+++ b/packages/hint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wp-g2/hint",
-  "version": "0.0.108",
+  "version": "0.0.109-alpha.0",
   "description": "UI linter for G2 Components.",
   "main": "dist/cjs/index.js",
   "module": "dist/es/index.js",
@@ -15,7 +15,7 @@
   "author": "Jon Quach <hello@jonquach.com> (https://jonquach.com)",
   "license": "MIT",
   "dependencies": {
-    "@wp-g2/components": "^0.0.108",
+    "@wp-g2/components": "^0.0.109-alpha.0",
     "@wp-g2/icons": "^0.0.108",
     "@wp-g2/styles": "^0.0.108",
     "@wp-g2/utils": "^0.0.108"

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wp-g2/website",
-  "version": "0.0.108",
+  "version": "0.0.109-alpha.0",
   "private": true,
   "description": "Documentatoin website for G2 Components.",
   "author": "Jon Quach <hello@jonquach.com>",
@@ -21,7 +21,7 @@
     "@mdx-js/mdx": "^1.6.16",
     "@mdx-js/react": "^1.6.16",
     "@wordpress/icons": "^2.8.0",
-    "@wp-g2/components": "^0.0.108",
+    "@wp-g2/components": "^0.0.109-alpha.0",
     "@wp-g2/gatsby-plugin-styles": "^0.0.108",
     "@wp-g2/styles": "^0.0.108",
     "@wp-g2/utils": "^0.0.108",


### PR DESCRIPTION
This update resolves the `FontSizeControl` component `onChange` handling (for custom items) for Gutenberg.
It also ensures that `Button` components render more consistently within the Gutenberg UI, using a `height` reset.

Resolves https://github.com/ItsJonQ/g2/issues/179