### PR TITLE
SelectDropdown: Add isPreviewable interaction

### DIFF
--- a/packages/components/src/font-size-control/__stories__/index.stories.js
+++ b/packages/components/src/font-size-control/__stories__/index.stories.js
@@ -28,9 +28,11 @@ const fontSizes = [
 
 export const _default = () => {
 	const [value, setValue] = React.useState(fontSizes[1].size);
+
 	const handleOnChange = (next) => {
 		setValue(next);
 	};
+
 	const renderItem = React.useCallback(({ name, size }) => {
 		return (
 			<div

--- a/packages/components/src/select-dropdown/__stories__/index.stories.js
+++ b/packages/components/src/select-dropdown/__stories__/index.stories.js
@@ -1,7 +1,9 @@
+import { ui } from '@wp-g2/styles';
 import React from 'react';
 
 import { Grid } from '../../Grid';
 import { Text } from '../../Text';
+import { View } from '../../View';
 import { SelectDropdown } from '../index';
 
 export default {
@@ -34,6 +36,7 @@ export const _default = () => {
 		<div>
 			<Grid>
 				<SelectDropdown
+					isPreviewable
 					onChange={handleOnChange}
 					options={options}
 					placeholder="Element"
@@ -91,5 +94,58 @@ export const _inlineRendering = () => {
 				place with your.
 			</Text>
 		</div>
+	);
+};
+
+const presets = [
+	{ name: '0px', value: '0px', size: 0 },
+	{ name: '4px', value: '4px', size: 4 },
+	{ name: '8px', value: '8px', size: 8 },
+	{ name: '12px', value: '12px', size: 12 },
+	{ name: '16px', value: '16px', size: 16 },
+	{ name: '20px', value: '20px', size: 20 },
+];
+
+export const _preview = () => {
+	const [value, setValue] = React.useState(presets[2]);
+
+	const handleOnChange = (next) => {
+		setValue(next.selectedItem);
+	};
+
+	return (
+		<Grid>
+			<SelectDropdown
+				isPreviewable
+				onChange={handleOnChange}
+				options={presets}
+				placeholder="Element"
+				value={value}
+			/>
+			<View>
+				<View
+					css={{
+						background: 'rgba(0, 0, 255, 0.1)',
+						border: '2px solid rgba(0, 0, 255, 0.1)',
+						display: 'inline-block',
+					}}
+					style={{ padding: value?.size }}
+				>
+					<View
+						css={[
+							{
+								background: 'blue',
+								color: 'white',
+								width: 50,
+								height: 50,
+							},
+							ui.alignment.content.center,
+						]}
+					>
+						{value.value}
+					</View>
+				</View>
+			</View>
+		</Grid>
 	);
 };

--- a/packages/components/src/select-dropdown/select-dropdown-utils.js
+++ b/packages/components/src/select-dropdown/select-dropdown-utils.js
@@ -1,3 +1,4 @@
+import { is, memoize } from '@wp-g2/utils';
 import { useSelect } from 'downshift';
 
 export const itemToString = (item) => item?.name || item?.label;
@@ -40,3 +41,26 @@ export const stateReducer = (
 			return changes;
 	}
 };
+
+/**
+ * Retreives the current selected item from a collection of items.
+ * This is useful to ensure the correct item is passed into Downshift for
+ * it's internal equality checks.
+ *
+ * @param {Array<*>} items A collection of items
+ * @param {*} value The current value
+ *
+ * @returns {*} The selected item.
+ */
+function _getSelectedItem(items = [], value) {
+	if (is.plainObject(value)) {
+		const selectedItem = items.find(
+			(item) => item === value || item?.value === value?.value,
+		);
+		return selectedItem || value;
+	}
+
+	return value;
+}
+
+export const getSelectedItem = memoize(_getSelectedItem);

--- a/packages/components/src/select-dropdown/select-dropdown.js
+++ b/packages/components/src/select-dropdown/select-dropdown.js
@@ -39,7 +39,6 @@ function SelectDropdown(props, forwardedRef) {
 					{isOpen && (
 						<DropdownMenuCard {...dropdownMenuProps}>
 							{items.map((item) => (
-								// eslint-disable-next-line react/jsx-key
 								<SelectDropdownItem {...item} />
 							))}
 						</DropdownMenuCard>


### PR DESCRIPTION
This update adds the ability for `SelectDropdown` to "preview" changes when hovering/moving through the items (without committing the change via a click).

Example:
![Screen Capture on 2020-12-09 at 15-54-20](https://user-images.githubusercontent.com/2322354/101686629-4dee3080-3a37-11eb-9fa8-62e746ecd7de.gif)

This is an opt-in feature, via a `<SelectDropdown isPreviewable />` prop.

The best part is the consumer doesn't have to tap into an alternative callback function for the preview function to work.
All of that is handled internally between a substate store and Downshift.

For fun, here's the state flow diagram I drew during the [Twitch stream](https://www.twitch.tv/videos/831237124) today when we were trying to figure this out.

<img width="1200" alt="Screen Shot 2020-12-09 at 1 46 33 PM" src="https://user-images.githubusercontent.com/2322354/101686786-8988fa80-3a37-11eb-8a0d-949d6b8f49cc.png">

Shout outs to @timothybjacobs for contributing ideas for this interaction!

Resolves https://github.com/ItsJonQ/g2/issues/182