### PR TITLE
Remove automatic ref forwarding in core elements

### DIFF
--- a/packages/create-styles/src/create-style-system/create-core-element.js
+++ b/packages/create-styles/src/create-style-system/create-core-element.js
@@ -82,7 +82,6 @@ export const createCoreElement = (tagName, options) => {
 			as,
 			children,
 			className: classNameProp,
-			forwardedRef,
 			...props
 		},
 		ref,
@@ -136,16 +135,11 @@ export const createCoreElement = (tagName, options) => {
 			}
 		}
 
-		// eslint-disable-next-line
-		const refs = React.useMemo(() => {
-			return mergeRefs([forwardedRef, ref]);
-		}, [forwardedRef, ref]);
-
 		return React.createElement(
 			element,
 			{
 				className: classes,
-				ref: refs,
+				ref,
 				...newProps,
 			},
 			children,

--- a/packages/create-styles/src/create-style-system/create-core-element.js
+++ b/packages/create-styles/src/create-style-system/create-core-element.js
@@ -82,6 +82,7 @@ export const createCoreElement = (tagName, options) => {
 			as,
 			children,
 			className: classNameProp,
+			forwardedRef,
 			...props
 		},
 		ref,
@@ -135,11 +136,16 @@ export const createCoreElement = (tagName, options) => {
 			}
 		}
 
+		// eslint-disable-next-line
+		const refs = React.useMemo(() => {
+			return forwardedRef ? mergeRefs([forwardedRef, ref]) : ref;
+		}, [forwardedRef, ref]);
+
 		return React.createElement(
 			element,
 			{
 				className: classes,
-				ref,
+				ref: refs,
 				...newProps,
 			},
 			children,


### PR DESCRIPTION
### Testing instructions

run `yarn start`, open Storybook and ensure nothing is broken, especially in components that use forwarded refs like `TextInput`. Ensure refs of core elements are able to be retrieved (for eample in `TextInput` where we retrieve a ref of a `View` which is just the `div` core element).