### PR TITLE
Fix: Font size picker calls on change on each rerender.

### DIFF
--- a/packages/components/src/font-size-control/__stories__/index.stories.js
+++ b/packages/components/src/font-size-control/__stories__/index.stories.js
@@ -54,3 +54,46 @@ export const _default = () => {
 		</div>
 	);
 };
+
+export const _periodicRerender = () => {
+	const [timer, setTimer] = React.useState(0);
+	const [value, setValue] = React.useState(undefined);
+
+	const handleOnChange = (next) => {
+		console.log('handleOnChange', next, value);
+		setValue(next);
+	};
+
+	React.useEffect(() => {
+		const timeout = setTimeout(() => {
+			setTimer(timer + 1);
+		}, 1000);
+		return () => clearTimeout(timeout);
+	}, [timer]);
+
+	const renderItem = React.useCallback(({ name, size }) => {
+		return (
+			<div
+				style={{
+					fontSize: size,
+				}}
+			>
+				{name}
+			</div>
+		);
+	}, []);
+
+	return (
+		<div>
+			{timer}
+			<Grid templateColumns="260px 260px 1fr">
+				<FontSizeControl
+					fontSizes={fontSizes}
+					onChange={handleOnChange}
+					renderItem={renderItem}
+					value={value}
+				/>
+			</Grid>
+		</div>
+	);
+};

--- a/packages/components/src/font-size-control/font-size-control-utils.js
+++ b/packages/components/src/font-size-control/font-size-control-utils.js
@@ -55,9 +55,8 @@ export function getSelectOptions({
 			: option.size;
 
 		return {
+			...option,
 			key: option.slug,
-			name: option.name,
-			size: option.size,
 			style: {
 				fontSize: `min( ${fontSize}, ${MAX_FONT_SIZE_DISPLAY} )`,
 			},

--- a/packages/components/src/font-size-control/font-size-control-utils.js
+++ b/packages/components/src/font-size-control/font-size-control-utils.js
@@ -17,7 +17,7 @@ function getFontSize(values = [], value) {
 	return item;
 }
 
-function isCustomValue(values = [], value) {
+export function isCustomValue(values = [], value) {
 	const item = getFontSize(values, value);
 	return !!item;
 }
@@ -33,7 +33,11 @@ export function getSelectValueFromFontSize(fontSizes, value) {
 	return fontSize ? fontSize.slug : CUSTOM_FONT_SIZE;
 }
 
-export function getSelectOptions({ disableCustomFontSizes, options, value }) {
+export function getSelectOptions({
+	disableCustomFontSizes,
+	hasCustomValue,
+	options,
+}) {
 	if (disableCustomFontSizes && !options.length) return null;
 
 	options = [
@@ -41,7 +45,7 @@ export function getSelectOptions({ disableCustomFontSizes, options, value }) {
 		...options,
 	];
 
-	if (!isCustomValue(options, value) && !disableCustomFontSizes) {
+	if (!hasCustomValue && !disableCustomFontSizes) {
 		options.push({ slug: CUSTOM_FONT_SIZE, name: __('Custom') });
 	}
 

--- a/packages/components/src/font-size-control/use-font-size-control.js
+++ b/packages/components/src/font-size-control/use-font-size-control.js
@@ -11,6 +11,7 @@ import {
 	getSelectValueFromFontSize,
 	hasUnit,
 	isCustomSelectedItem,
+	isCustomValue,
 } from './font-size-control-utils';
 
 export function useFontSizeControl(props) {
@@ -38,11 +39,17 @@ export function useFontSizeControl(props) {
 
 	const hasUnits = hasUnit(value || fontSizes[0]?.size);
 
-	const options = getSelectOptions({
-		options: fontSizes,
-		disableCustomFontSizes,
-		value,
-	});
+	const hasCustomValue = isCustomValue(fontSizes, value);
+
+	const options = React.useMemo(
+		() =>
+			getSelectOptions({
+				options: fontSizes,
+				disableCustomFontSizes,
+				hasCustomValue,
+			}),
+		[fontSizes, disableCustomFontSizes, hasCustomValue],
+	);
 
 	const handleOnReset = React.useCallback(() => {
 		onChange(undefined);

--- a/packages/components/src/select-dropdown/use-select-dropdown.js
+++ b/packages/components/src/select-dropdown/use-select-dropdown.js
@@ -1,7 +1,13 @@
 import { useContextSystem } from '@wp-g2/context';
 import { css, cx, ui } from '@wp-g2/styles';
 import { shallowCompare, useSubState } from '@wp-g2/substate';
-import { mergeRefs, noop, useResizeAware, useUpdateEffect } from '@wp-g2/utils';
+import {
+	mergeRefs,
+	noop,
+	simpleEqual,
+	useResizeAware,
+	useUpdateEffect,
+} from '@wp-g2/utils';
 import { useSelect } from 'downshift';
 import { useCallback, useEffect, useRef } from 'react';
 
@@ -91,7 +97,10 @@ function useSelectDropdownStore({ isPreviewable, onChange, value }) {
 
 	// Sync incoming value.
 	useUpdateEffect(() => {
-		if (!store.getState().isOpen) {
+		if (
+			!store.getState().isOpen &&
+			!simpleEqual(store.getState().commitValue, value)
+		) {
 			store.getState().setCommitValue(value);
 		}
 	}, [value, store]);


### PR DESCRIPTION
Currently, the FontSizePicker component makes an onChange call each time the component is rerendered.
The story I'm adding shows the issue in action.

This PR fixes the issue by making sure we are not generating new options on each rerender.
This PR fixes part of the end to end tests failures on https://github.com/WordPress/gutenberg/pull/27594.
Currently each time a block rerenders, the font size picker rerenders, and then we dispatch update block attribute actions.

I think that we also have an issue on the SelectDropdown component  (it is the one throwing onChange calls), but I did not manage to replicate this issue using that component in isolation after multiple tries where on each rerender I passed different objects.


I verified using the developer tools and the story I proposed that on each rerender we are not making on Change calls.