### PR TITLE
Fix: Text Input when value changes externally it becomes undeletable

### DIFF
--- a/packages/components/src/TextInput/__stories__/TextInput.stories.js
+++ b/packages/components/src/TextInput/__stories__/TextInput.stories.js
@@ -1,9 +1,8 @@
-import { ui } from '@wp-g2/styles';
 import React from 'react';
 import NumberFormat from 'react-number-format';
 
 import { Container } from '../../Container';
-import { Select, Text, View, VStack } from '../../index';
+import { Text, VStack } from '../../index';
 import { TextInput } from '../index';
 
 export default {
@@ -25,6 +24,17 @@ export const number = () => {
 		>
 			<TextInput type="number" />
 		</Container>
+	);
+};
+
+export const numberWithExternalChange = () => {
+	const [value, setValue] = React.useState();
+	return (
+		<div>
+			<div>Value: {value}</div>
+			<button onClick={() => setValue(10)}>Make ten</button>
+			<TextInput onChange={setValue} type="number" value={value} />
+		</div>
 	);
 };
 

--- a/packages/components/src/TextInput/useTextInputState.js
+++ b/packages/components/src/TextInput/useTextInputState.js
@@ -84,6 +84,7 @@ const reducer = (state, action) => {
 		case actionTypes.sync:
 			return {
 				previousValue: action.payload.value,
+				commitValue: action.payload.value,
 				value: action.payload.value,
 			};
 


### PR DESCRIPTION
The sync action called when the value changes externally to synchronize the local state was making commitValue undefined.

We have this effect to call onChange when the value changes:
```
	React.useEffect(() => {
		return store.subscribe(
			(value) => {
				onChange(value);
			},
			(state) => state.commitValue,
			shallowCompare,
		);
	}, [onChange, store]);
```

If the value updates externally, and then we delete the value, onChange is not called because in that case, commitValue does not change.
This PR fixes the issue by making sure commitValue is updated during the synchronization.


As an aside, it this a good practice to don't synchronize state:
https://kentcdodds.com/blog/dont-sync-state-derive-it

We rely a lot on state synchronization. I guess we should try to update our components to be less dependent on the local state and more on the props that are passed to them. Props should be the source of truth.

On the TextInput component, we have two stores and three different state vars for value, previousValue, commitValue, and value.
Could we remove the number of variables we have? I guess, for example, we can remove commitValue the prop value could be the commitValue. A value is committed when the prop reflects it.
And then I guess we just need the local state for a temporary invalid input, e.g: if the min number is 50 we will store in this temporary location "5" to allow the user to type "50". Once a value is valid, it is committed right away, and the source of truth becomes the prop. So, in that case, we would just have a temporary value or something similar as local state. Would this work? What makes us need to have more variables?