### PR TITLE
Fix: Remove renderItem prop from font size picker

### DIFF
--- a/packages/components/src/font-size-control/__stories__/index.stories.js
+++ b/packages/components/src/font-size-control/__stories__/index.stories.js
@@ -53,7 +53,6 @@ export const _default = () => {
 					isPreviewable
 					onChange={handleOnChange}
 					placeholder="Element"
-					renderItem={renderItem}
 					value={value}
 					withSlider
 				/>
@@ -61,7 +60,6 @@ export const _default = () => {
 					fontSizes={fontSizes}
 					onChange={handleOnChange}
 					placeholder="Element"
-					renderItem={renderItem}
 					value={value}
 				/>
 			</Grid>

--- a/packages/components/src/font-size-control/__stories__/index.stories.js
+++ b/packages/components/src/font-size-control/__stories__/index.stories.js
@@ -33,18 +33,6 @@ export const _default = () => {
 		setValue(next);
 	};
 
-	const renderItem = React.useCallback(({ name, size }) => {
-		return (
-			<div
-				style={{
-					fontSize: size,
-				}}
-			>
-				{name}
-			</div>
-		);
-	}, []);
-
 	return (
 		<div>
 			<Grid templateColumns="260px 260px 1fr">

--- a/packages/components/src/font-size-control/use-font-size-control.js
+++ b/packages/components/src/font-size-control/use-font-size-control.js
@@ -30,7 +30,6 @@ export function useFontSizeControl(props) {
 		onClose,
 		onOpen,
 		placeholder,
-		renderItem,
 		size,
 		value,
 		withSlider = false,
@@ -102,7 +101,6 @@ export function useFontSizeControl(props) {
 		onClose,
 		onOpen,
 		placeholder,
-		renderItem,
 	};
 
 	return {


### PR DESCRIPTION
The FontSizePicker had a renderItem prop. But that prop made the default unused:
https://github.com/ItsJonQ/g2/blob/3213c5991dd72c3ebe78eaa6d71e82beb3530ece/packages/components/src/font-size-control/font-size-control-select.js#L37-L40.
That happens because when spreading even if the prop is undefined we are overwriting the default. The current font size picker on component does not offer a renderItem component so I guess we can continue to not offer it https://github.com/ItsJonQ/g2/blob/3213c5991dd72c3ebe78eaa6d71e82beb3530ece/packages/components/src/font-size-control/font-size-control-select.js#L55