### PR TITLE
SelectDropdown: Focus "select" button on select action

### DIFF
--- a/packages/components/src/select-dropdown/use-select-dropdown.js
+++ b/packages/components/src/select-dropdown/use-select-dropdown.js
@@ -3,7 +3,7 @@ import { css, cx, ui } from '@wp-g2/styles';
 import { shallowCompare, useSubState } from '@wp-g2/substate';
 import { mergeRefs, noop, useResizeAware, useUpdateEffect } from '@wp-g2/utils';
 import { useSelect } from 'downshift';
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
 import { useFormGroupContextId } from '../FormGroup';
 import { usePositioner } from '../positioner';
@@ -140,6 +140,8 @@ export function useSelectDropdown(props) {
 	);
 	const currentItem = getSelectedItem(items, commitValue);
 
+	const selectRef = useRef();
+
 	const handleOnChange = useCallback(
 		(next) => {
 			store.getState().setCommitValue(next.selectedItem);
@@ -194,16 +196,25 @@ export function useSelectDropdown(props) {
 
 	const id = useFormGroupContextId(idProp);
 
+	const focusSelectButton = useCallback(() => {
+		if (selectRef.current) {
+			selectRef.current.focus();
+		}
+	}, []);
+
 	const handleOnOpen = useCallback(() => {
 		store.getState().setOpen(true);
+
 		onOpen();
 	}, [onOpen, store]);
 
 	const handleOnClose = useCallback(() => {
 		store.getState().setOpen(false);
 		store.getState().resetValue();
+
+		focusSelectButton();
 		onClose();
-	}, [onClose, store]);
+	}, [focusSelectButton, onClose, store]);
 
 	const _popoverProps = getMenuProps({
 		...ui.$('SelectDropdownPopover'),
@@ -246,7 +257,7 @@ export function useSelectDropdown(props) {
 		isSubtle,
 		prefix,
 		suffix,
-		ref: mergeRefs([_referenceProps.ref, referenceRef]),
+		ref: mergeRefs([_referenceProps.ref, referenceRef, selectRef]),
 		size,
 		textAlign,
 		variant,


### PR DESCRIPTION
This update ensures that the "select" (`button`) is focused after a selection action is made (either with mouse events or keyboard events).

The solution involved creating an internal `ref` for the `button` element, and (force) focusing that element within the `close` callback.

![Screen Capture on 2021-01-04 at 17-30-37](https://user-images.githubusercontent.com/2322354/103586206-9bcd4b80-4eb2-11eb-837e-969d43faa4e1.gif)

GIF above shows the Select element being focused (highlighted) after selecting an item.

Resolves https://github.com/ItsJonQ/g2/issues/208