### PR TITLE
Remove usages of is.function, is.string, and is.array.

### DIFF
--- a/packages/components/src/Accordion/useAccordion.js
+++ b/packages/components/src/Accordion/useAccordion.js
@@ -1,6 +1,6 @@
 import { useContextSystem } from '@wp-g2/context';
 import { shallowCompare, useSubState } from '@wp-g2/substate';
-import { is, noop, simpleEqual, useUpdateEffect } from '@wp-g2/utils';
+import { noop, simpleEqual, useUpdateEffect } from '@wp-g2/utils';
 import { uniq } from 'lodash';
 import { useCallback, useEffect, useMemo } from 'react';
 
@@ -9,7 +9,7 @@ import { useCallback, useEffect, useMemo } from 'react';
  * @returns {curent is any[] | string}
  */
 const isCurrentValid = (current) =>
-	Array.isArray(current) || is.string(current);
+	Array.isArray(current) || typeof current === 'string';
 
 /**
  * @param {string[]} next

--- a/packages/components/src/Accordion/useAccordion.js
+++ b/packages/components/src/Accordion/useAccordion.js
@@ -8,7 +8,8 @@ import { useCallback, useEffect, useMemo } from 'react';
  * @param {any} current
  * @returns {curent is any[] | string}
  */
-const isCurrentValid = (current) => is.array(current) || is.string(current);
+const isCurrentValid = (current) =>
+	Array.isArray(current) || is.string(current);
 
 /**
  * @param {string[]} next
@@ -21,7 +22,9 @@ const sanitizeState = (next) => uniq(next.filter(Boolean));
  */
 const setCurrentState = (prev = [], next) => {
 	if (!isCurrentValid(next)) return prev;
-	const nextState = is.array(next) ? [...prev, ...next] : [...prev, next];
+	const nextState = Array.isArray(next)
+		? [...prev, ...next]
+		: [...prev, next];
 
 	return sanitizeState(nextState);
 };
@@ -102,7 +105,7 @@ export function useAccordion(props) {
 				return accordionStore.getState().add(next);
 			}
 			set(() => {
-				const nextState = is.array(next) ? [next[0]] : [next];
+				const nextState = Array.isArray(next) ? [next[0]] : [next];
 				return { current: sanitizeState(nextState) };
 			});
 		},

--- a/packages/components/src/Animated/Animated.js
+++ b/packages/components/src/Animated/Animated.js
@@ -1,5 +1,4 @@
 import { contextConnect } from '@wp-g2/context';
-import { is } from '@wp-g2/utils';
 import React from 'react';
 
 import { createAnimated } from './Animated.utils';
@@ -8,7 +7,7 @@ import { useAnimated } from './useAnimated';
 function Animated(props, forwardedRef) {
 	const { as, children, ...otherProps } = useAnimated(props);
 
-	const tagName = is.string(as) ? as : 'div';
+	const tagName = typeof as === 'string' ? as : 'div';
 	const Component = createAnimated(tagName);
 
 	return (

--- a/packages/components/src/BaseModal/BaseModal.js
+++ b/packages/components/src/BaseModal/BaseModal.js
@@ -1,7 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import { contextConnect, useContextSystem } from '@wp-g2/context';
 import { css, cx, getZIndex, reducedMotion, space } from '@wp-g2/styles';
-import { is } from '@wp-g2/utils';
 import React from 'react';
 import { Dialog, DialogBackdrop, useDialogState } from 'reakit';
 
@@ -83,7 +82,7 @@ function BaseModal(props, forwardedRef) {
 
 	return (
 		<ModalContext.Provider value={contextProps}>
-			{is.function(triggerProp)
+			{typeof triggerProp === 'function'
 				? triggerProp(dialog)
 				: triggerProp
 				? triggerProp

--- a/packages/components/src/ColorPicker/ColorPickerInputs.js
+++ b/packages/components/src/ColorPicker/ColorPickerInputs.js
@@ -71,7 +71,7 @@ export const ColorInputSlider = React.memo(
 		const handleOnChange = React.useCallback(
 			(next) => {
 				let changeValue = next;
-				if (is.function(serialize)) {
+				if (typeof serialize === 'function') {
 					changeValue = serialize(changeValue);
 				}
 				setValue({ [prop]: changeValue });
@@ -81,7 +81,7 @@ export const ColorInputSlider = React.memo(
 
 		let parsedValue = value;
 
-		if (is.function(parse)) {
+		if (typeof parse === 'function') {
 			parsedValue = parse(value);
 		}
 

--- a/packages/components/src/Flex/useFlex.js
+++ b/packages/components/src/Flex/useFlex.js
@@ -1,6 +1,5 @@
 import { useContextSystem } from '@wp-g2/context';
 import { css, cx, ui, useResponsiveValue } from '@wp-g2/styles';
-import { is } from '@wp-g2/utils';
 import { useMemo } from 'react';
 
 import * as styles from './Flex.styles';
@@ -36,8 +35,10 @@ export function useFlex(props) {
 
 	const direction = useResponsiveValue(directionProp);
 
-	const isColumn = is.string(direction) && !!direction.includes('column');
-	const isReverse = is.string(direction) && direction.includes('reverse');
+	const isColumn =
+		typeof direction === 'string' && !!direction.includes('column');
+	const isReverse =
+		typeof direction === 'string' && direction.includes('reverse');
 
 	const classes = useMemo(() => {
 		const sx = {};

--- a/packages/components/src/Initials/Initials.utils.js
+++ b/packages/components/src/Initials/Initials.utils.js
@@ -1,7 +1,5 @@
-import { is } from '@wp-g2/utils';
-
 export function getInitials(name = '') {
-	if (!is.string(name)) return '';
+	if (typeof name !== 'string') return '';
 
 	const names = name
 		.split(' ')

--- a/packages/components/src/ListGroup/ListGroupFooter.js
+++ b/packages/components/src/ListGroup/ListGroupFooter.js
@@ -4,7 +4,6 @@ import {
 	useContextSystem,
 } from '@wp-g2/context';
 import { cx } from '@wp-g2/styles';
-import { is } from '@wp-g2/utils';
 import React from 'react';
 
 import { FlexItem } from '../Flex';
@@ -27,7 +26,7 @@ function ListGroupFooter(props, forwardedRef) {
 
 	const clonedChildren = validChildren.map((child, index) => {
 		const _key = child.key || index;
-		const isTitle = is.string(child);
+		const isTitle = typeof child === 'string';
 
 		return isTitle ? (
 			<FlexItem isBlock key={_key}>

--- a/packages/components/src/ListGroup/ListGroupHeader.js
+++ b/packages/components/src/ListGroup/ListGroupHeader.js
@@ -4,7 +4,6 @@ import {
 	useContextSystem,
 } from '@wp-g2/context';
 import { cx } from '@wp-g2/styles';
-import { is } from '@wp-g2/utils';
 import React from 'react';
 
 import { FlexItem } from '../Flex';
@@ -26,7 +25,7 @@ function ListGroupHeader(props, forwardedRef) {
 
 	const clonedChildren = validChildren.map((child, index) => {
 		const _key = child.key || index;
-		const isTitle = is.string(child);
+		const isTitle = typeof child === 'string';
 
 		return isTitle ? (
 			<FlexItem isBlock key={_key}>

--- a/packages/components/src/Select/useSelect.js
+++ b/packages/components/src/Select/useSelect.js
@@ -107,7 +107,8 @@ export function useSelect(props) {
 	);
 
 	const shouldRenderPlaceholder =
-		(!is.defined(value) || is.empty(value)) && is.string(placeholderProp);
+		(!is.defined(value) || is.empty(value)) &&
+		typeof placeholderProp === 'string';
 
 	const classes = cx(baseFieldProps.className, styles.base, className);
 

--- a/packages/components/src/Text/Text.utils.js
+++ b/packages/components/src/Text/Text.utils.js
@@ -1,5 +1,5 @@
 import { ui } from '@wp-g2/styles';
-import { is, memoize } from '@wp-g2/utils';
+import { memoize } from '@wp-g2/utils';
 import { findAll } from 'highlight-words-core';
 import { createElement } from 'react';
 
@@ -47,7 +47,7 @@ export function createHighlighterText({
 	unhighlightStyle,
 }) {
 	if (!children) return null;
-	if (!is.string(children)) return children;
+	if (typeof children !== 'string') return children;
 
 	const textToHighlight = children;
 

--- a/packages/components/src/Text/useText.js
+++ b/packages/components/src/Text/useText.js
@@ -37,7 +37,8 @@ export function useText(props) {
 	} = useContextSystem(props, 'Text');
 
 	let content = children;
-	const isHighlighter = is.array(highlightWords) && highlightWords.length;
+	const isHighlighter =
+		Array.isArray(highlightWords) && highlightWords.length;
 	const isCaption = size === 'caption';
 
 	if (isHighlighter) {
@@ -133,7 +134,7 @@ export function useText(props) {
 	/**
 	 * Enhance child `<Link />` components to inherit font size.
 	 */
-	if (!truncate && is.array(children)) {
+	if (!truncate && Array.isArray(children)) {
 		content = React.Children.map(children, (child) => {
 			// @ts-ignore
 			if (!is.plainObject(child) || !('props' in child)) {

--- a/packages/components/src/TextInput/useTextInputState.js
+++ b/packages/components/src/TextInput/useTextInputState.js
@@ -210,7 +210,7 @@ const useTextInputStore = ({
 		dispatch: (args) =>
 			set((state) => {
 				const next = reducer(state, args);
-				if (is.function(__debugger)) {
+				if (typeof __debugger === 'function') {
 					__debugger(args, next, state);
 				}
 				return next;
@@ -234,7 +234,7 @@ const useTextInputStore = ({
 		},
 		commit: () => {
 			let isValid = true;
-			const hasValidation = is.function(validate);
+			const hasValidation = typeof validate === 'function';
 			const current = store.getState();
 
 			current.dispatch({

--- a/packages/components/src/Truncate/Truncate.utils.js
+++ b/packages/components/src/Truncate/Truncate.utils.js
@@ -19,7 +19,7 @@ export const TRUNCATE_DEFAULT_PROPS = {
 // Source
 // https://github.com/kahwee/truncate-middle
 export function truncateMiddle(word, headLength, tailLength, ellipsis) {
-	if (!is.string(word)) {
+	if (typeof word !== 'string') {
 		return '';
 	}
 	const wordLength = word.length;

--- a/packages/components/src/Truncate/useTruncate.js
+++ b/packages/components/src/Truncate/useTruncate.js
@@ -1,6 +1,5 @@
 import { useContextSystem } from '@wp-g2/context';
 import { css, cx } from '@wp-g2/styles';
-import { is } from '@wp-g2/utils';
 import { useMemo } from 'react';
 
 import * as styles from './Truncate.styles';
@@ -33,7 +32,7 @@ export function useTruncate(props) {
 	} = useContextSystem(props, 'Truncate');
 
 	const truncatedContent = truncateContent(
-		is.string(children) ? children : '',
+		typeof children === 'string' ? children : '',
 		{
 			ellipsis,
 			ellipsizeMode,

--- a/packages/components/src/Viewport/Viewport.utils.js
+++ b/packages/components/src/Viewport/Viewport.utils.js
@@ -16,7 +16,7 @@ export function getBreakpointValue(breakpoint) {
 	if (is.number(breakpoint)) {
 		return { minWidth: breakpoint };
 	}
-	if (is.string(breakpoint)) {
+	if (typeof breakpoint === 'string') {
 		const value = BREAKPOINTS[breakpoint];
 		return value ? { minWidth: value } : breakpoint;
 	}

--- a/packages/components/src/__stories__/WIP/Toolbar.stories.js
+++ b/packages/components/src/__stories__/WIP/Toolbar.stories.js
@@ -220,7 +220,7 @@ const MoreItems = React.forwardRef((props, ref) => {
 
 function iconStringToToolbarComponents(icons) {
 	return (items, mapIndex) => {
-		if (!is.array(items)) return null;
+		if (!Array.isArray(items)) return null;
 
 		return (
 			<ToolbarGroup key={mapIndex}>
@@ -240,7 +240,8 @@ const templateToIconString = (item) => {
 		return `Fi${next}`;
 	}
 
-	if (is.array(item)) return item.map(templateToIconString).filter(Boolean);
+	if (Array.isArray(item))
+		return item.map(templateToIconString).filter(Boolean);
 
 	return undefined;
 };

--- a/packages/components/src/__stories__/WIP/Toolbar.stories.js
+++ b/packages/components/src/__stories__/WIP/Toolbar.stories.js
@@ -235,7 +235,7 @@ function iconStringToToolbarComponents(icons) {
 }
 
 const templateToIconString = (item) => {
-	if (is.string(item)) {
+	if (typeof item === 'string') {
 		const next = item.replace(/ /g, '');
 		return `Fi${next}`;
 	}
@@ -247,7 +247,7 @@ const templateToIconString = (item) => {
 };
 
 function generateToolbarComponentsFromTemplate(template, icons) {
-	if (!is.string(template)) return null;
+	if (typeof template !== 'string') return null;
 
 	const items = template
 		.split('|')

--- a/packages/components/src/font-size-control/font-size-control-utils.js
+++ b/packages/components/src/font-size-control/font-size-control-utils.js
@@ -72,7 +72,7 @@ export function getInputValue(fontSizes = [], value) {
 	}
 
 	const isPixelValue =
-		is.number(value) || (is.string(value) && value.endsWith('px'));
+		is.number(value) || (typeof value === 'string' && value.endsWith('px'));
 
 	const inputValue = (isPixelValue && noUnitsValue) || '';
 

--- a/packages/context/src/context-connect.js
+++ b/packages/context/src/context-connect.js
@@ -28,7 +28,7 @@ export function contextConnect(Component, namespace, options = {}) {
 		WrappedComponent = React.memo(WrappedComponent);
 	}
 
-	const displayName = is.array(namespace)
+	const displayName = Array.isArray(namespace)
 		? namespace[0]
 		: namespace || WrappedComponent.name;
 
@@ -39,7 +39,7 @@ export function contextConnect(Component, namespace, options = {}) {
 	/**
 	 * Consolidate (merge) namespaces before attaching it to the WrappedComponent.
 	 */
-	if (is.array(namespace)) {
+	if (Array.isArray(namespace)) {
 		mergedNamespace = [...mergedNamespace, ...namespace];
 	}
 	if (is.string(namespace)) {
@@ -76,7 +76,7 @@ export function hasConnectNamespace(Component, match) {
 	if (is.string(match)) {
 		return getConnectNamespace(Component).includes(match);
 	}
-	if (is.array(match)) {
+	if (Array.isArray(match)) {
 		return match.some((result) =>
 			getConnectNamespace(Component).includes(result),
 		);

--- a/packages/context/src/context-connect.js
+++ b/packages/context/src/context-connect.js
@@ -1,4 +1,3 @@
-import { is } from '@wp-g2/utils';
 import { uniq } from 'lodash';
 import React, { forwardRef } from 'react';
 
@@ -42,7 +41,7 @@ export function contextConnect(Component, namespace, options = {}) {
 	if (Array.isArray(namespace)) {
 		mergedNamespace = [...mergedNamespace, ...namespace];
 	}
-	if (is.string(namespace)) {
+	if (typeof namespace === 'string') {
 		mergedNamespace = [...mergedNamespace, namespace];
 	}
 
@@ -73,7 +72,7 @@ export function getConnectNamespace(Component) {
 export function hasConnectNamespace(Component, match) {
 	if (!Component) return false;
 
-	if (is.string(match)) {
+	if (typeof match === 'string') {
 		return getConnectNamespace(Component).includes(match);
 	}
 	if (Array.isArray(match)) {

--- a/packages/context/src/use-context-system.js
+++ b/packages/context/src/use-context-system.js
@@ -1,5 +1,5 @@
 import { css, cx } from '@wp-g2/styles';
-import { is, memoize } from '@wp-g2/utils';
+import { memoize } from '@wp-g2/utils';
 import { kebabCase, omit, uniq } from 'lodash';
 
 import { CONNECTED_NAMESPACE } from './constants';
@@ -35,7 +35,7 @@ export function useContextSystem(props, namespace) {
 
 	const nextNs = ns(displayName);
 	for (const k in nextNs) {
-		if (is.string(nextNs[k])) {
+		if (typeof nextNs[k] === 'string') {
 			finalComponentProps[k] = nextNs[k];
 		}
 	}
@@ -91,7 +91,7 @@ export function useContextSystem(props, namespace) {
  * @returns {string} The generated CSS className.
  */
 function getStyledClassName(displayName) {
-	if (!displayName || !is.string(displayName)) return '';
+	if (!displayName || typeof displayName !== 'string') return '';
 
 	const kebab = kebabCase(displayName);
 	return `components-${kebab} wp-components-${kebab}`;
@@ -109,7 +109,7 @@ function getStyledClassNameFromKey(key) {
 	if (Array.isArray(key)) {
 		return cx(uniq(key).map(getStyledClassName));
 	}
-	if (is.string(key)) {
+	if (typeof key === 'string') {
 		return getStyledClassName(key);
 	}
 

--- a/packages/context/src/use-context-system.js
+++ b/packages/context/src/use-context-system.js
@@ -60,9 +60,10 @@ export function useContextSystem(props, namespace) {
 	);
 
 	// Provides the ability to customize the render of the component.
-	const rendered = is.function(initialMergedProps.renderChildren)
-		? initialMergedProps.renderChildren(initialMergedProps)
-		: initialMergedProps.children;
+	const rendered =
+		typeof initialMergedProps.renderChildren === 'function'
+			? initialMergedProps.renderChildren(initialMergedProps)
+			: initialMergedProps.children;
 
 	for (const k in initialMergedProps) {
 		/**

--- a/packages/context/src/use-context-system.js
+++ b/packages/context/src/use-context-system.js
@@ -25,7 +25,7 @@ export function useContextSystem(props, namespace) {
 	const { context } = store();
 	let contextProps;
 
-	const displayName = is.array(namespace) ? namespace[0] : namespace;
+	const displayName = Array.isArray(namespace) ? namespace[0] : namespace;
 
 	/** @type {ConnectedProps<P>} */
 	// @ts-ignore We fill in the missing properties below
@@ -106,7 +106,7 @@ function getStyledClassName(displayName) {
 function getStyledClassNameFromKey(key) {
 	if (!key) return '';
 
-	if (is.array(key)) {
+	if (Array.isArray(key)) {
 		return cx(uniq(key).map(getStyledClassName));
 	}
 	if (is.string(key)) {

--- a/packages/create-styles/src/components/theme-provider/utils.js
+++ b/packages/create-styles/src/components/theme-provider/utils.js
@@ -188,7 +188,7 @@ export function useThemeStyles({
 	const didInjectGlobalStyles = useRef(false);
 
 	if (!didInjectGlobalStyles.current && isGlobal && theme) {
-		if (is.function(injectGlobal)) {
+		if (typeof injectGlobal === 'function') {
 			try {
 				const globalStyles = transformValuesToVariablesString(
 					selector,

--- a/packages/create-styles/src/create-compiler/create-compiler.js
+++ b/packages/create-styles/src/create-compiler/create-compiler.js
@@ -43,7 +43,7 @@ export function createCompiler(options) {
 	const defaultPlugins = createPlugins({ key, specificityLevel, rootStore });
 
 	if (options.stylisPlugins) {
-		if (is.array(options.stylisPlugins)) {
+		if (Array.isArray(options.stylisPlugins)) {
 			mergedOptions.stylisPlugins = [
 				...defaultPlugins,
 				...options.stylisPlugins,

--- a/packages/create-styles/src/create-compiler/create-css.js
+++ b/packages/create-styles/src/create-compiler/create-css.js
@@ -32,7 +32,7 @@ export function createCSS(compile) {
 			return compile(responsive(arg));
 		}
 
-		if (is.array(arg)) {
+		if (Array.isArray(arg)) {
 			for (let i = 0, len = arg.length; i < len; i++) {
 				const n = arg[i];
 				if (is.objectInterpolation(n)) {

--- a/packages/create-styles/src/create-compiler/responsive.js
+++ b/packages/create-styles/src/create-compiler/responsive.js
@@ -1,5 +1,3 @@
-import { is } from '@wp-g2/utils';
-
 import { breakpoints } from './utils';
 
 // https://github.com/system-ui/theme-ui/blob/master/packages/css/src/index.ts#L224
@@ -27,7 +25,7 @@ export const responsive = (
 
 		if (value === null) continue;
 
-		if (!is.array(value)) {
+		if (!Array.isArray(value)) {
 			next[key] = value;
 			continue;
 		}

--- a/packages/create-styles/src/create-style-system/create-core-element.js
+++ b/packages/create-styles/src/create-style-system/create-core-element.js
@@ -1,5 +1,5 @@
 import isPropValid from '@emotion/is-prop-valid';
-import { is, mergeRefs } from '@wp-g2/utils';
+import { mergeRefs } from '@wp-g2/utils';
 import React, { forwardRef } from 'react';
 
 import { useHydrateGlobalStyles } from '../hooks';
@@ -101,9 +101,10 @@ export const createCoreElement = (tagName, options) => {
 		useHydrateGlobalStyles({ globalStyles, injectGlobal });
 
 		const element = as || tagName;
-		const className = !is.string(classNameProp)
-			? cx(classNameProp)
-			: classNameProp;
+		const className =
+			typeof classNameProp !== 'string'
+				? cx(classNameProp)
+				: classNameProp;
 
 		/**
 		 * Compiles all of the custom styles into classNames before binding it
@@ -121,7 +122,7 @@ export const createCoreElement = (tagName, options) => {
 		 * A conventient feature to (attempt to) filter out non HTML-friendly
 		 * props for HTMLElements.
 		 */
-		const shouldFilterProps = is.string(element);
+		const shouldFilterProps = typeof element === 'string';
 
 		/** @type {Record<string, any>} */
 		let newProps = {};
@@ -155,7 +156,7 @@ export const createCoreElement = (tagName, options) => {
 	const SystemComponent = forwardRef(render);
 
 	if (process.env.NODE_ENV === 'development') {
-		const displayName = is.string(tagName) ? tagName : 'Component';
+		const displayName = typeof tagName === 'string' ? tagName : 'Component';
 
 		SystemComponent.displayName = displayName;
 	}

--- a/packages/create-styles/src/create-style-system/create-styled-components.js
+++ b/packages/create-styles/src/create-style-system/create-styled-components.js
@@ -65,11 +65,12 @@ export function createStyledComponents({ compiler, core }) {
 			/*
 			 * Enhancing the displayName.
 			 */
-			StyledComponent.displayName = is.string(tagName)
-				? `Styled(${getDisplayName(tagName)})`
-				: is.defined(tagName?.displayName)
-				? tagName.displayName
-				: `Styled(${getDisplayName(tagName)})`;
+			StyledComponent.displayName =
+				typeof tagName === 'string'
+					? `Styled(${getDisplayName(tagName)})`
+					: is.defined(tagName?.displayName)
+					? tagName.displayName
+					: `Styled(${getDisplayName(tagName)})`;
 
 			/*
 			 * Enhancing .withComponent()
@@ -87,7 +88,7 @@ export function createStyledComponents({ compiler, core }) {
 				)(...interpolatedProps);
 			};
 
-			if (!is.string(tagName)) {
+			if (typeof tagName !== 'string') {
 				/*
 				 * Hoisting statics one last time, if the tagName is a Component,
 				 * rather than an HTML tag, like `div`.

--- a/packages/create-styles/src/create-style-system/utils.js
+++ b/packages/create-styles/src/create-style-system/utils.js
@@ -150,7 +150,7 @@ export function transformValuesToVariablesString(
  */
 export function compileInterpolatedStyles(interpolatedStyles, props) {
 	const compiledStyles = interpolatedStyles.map((a) =>
-		is.function(a) ? a(props) : a,
+		typeof a === 'function' ? a(props) : a,
 	);
 
 	return compiledStyles;

--- a/packages/hint/src/processor.js
+++ b/packages/hint/src/processor.js
@@ -62,7 +62,7 @@ export function process({ onReport } = { onReport: noop }) {
 	for (const node of nodes) {
 		for (const rule of rules) {
 			const [name, fns] = rule;
-			if (is.function(fns.create)) {
+			if (typeof fns.create === 'function') {
 				context.report = handleOnReport(name, node);
 				fns.create(context)(node, {
 					getComponentName,

--- a/packages/protokit/src/mockers/mockRequest.js
+++ b/packages/protokit/src/mockers/mockRequest.js
@@ -1,5 +1,3 @@
-import { is } from '@wp-g2/utils';
-
 const defaultMockRequestOptions = {
 	timeout: 500,
 	status: 200,
@@ -15,14 +13,14 @@ export async function mockRequest(options = defaultMockRequestOptions) {
 		setTimeout(() => {
 			if (status === 200) {
 				try {
-					if (is.function(action)) {
+					if (typeof action === 'function') {
 						action();
 					}
 				} catch (err) {
 					reject({ status: 400, message: err });
 				}
 
-				const response = is.function(data) ? data() : data;
+				const response = typeof data === 'function' ? data() : data;
 				return resolve(response, { status: 200, message });
 			} else {
 				return reject({ status, message });

--- a/packages/styles/src/css.js
+++ b/packages/styles/src/css.js
@@ -93,7 +93,7 @@ export function css(template, ...args) {
 		return compile(getScaleStyles(responsive(template, getScaleValue)));
 	}
 
-	if (is.array(template)) {
+	if (Array.isArray(template)) {
 		for (let i = 0, len = template.length; i < len; i++) {
 			const n = template[i];
 			if (is.objectInterpolation(n)) {

--- a/packages/styles/src/hooks/use-responsive-value.js
+++ b/packages/styles/src/hooks/use-responsive-value.js
@@ -1,4 +1,3 @@
-import { is } from '@wp-g2/utils';
 import { useEffect, useState } from 'react';
 
 import { breakpoints } from '../style-system';
@@ -62,7 +61,7 @@ export const useBreakpointIndex = (options = {}) => {
 export function useResponsiveValue(values, options = {}) {
 	const index = useBreakpointIndex(options);
 
-	if (!is.array(values) && typeof values !== 'function') return values;
+	if (!Array.isArray(values) && typeof values !== 'function') return values;
 
 	let array = values || [];
 	if (typeof values === 'function') {

--- a/packages/styles/src/hooks/use-responsive-value.js
+++ b/packages/styles/src/hooks/use-responsive-value.js
@@ -55,17 +55,17 @@ export const useBreakpointIndex = (options = {}) => {
 /**
  *
  * @template T
- * @param {(() => (T | undefined)[]) | (T | undefined)[] | T | undefined} values
+ * @param {(() => (T | undefined)[]) | (T | undefined)[]} values
  * @param {Parameters<useBreakpointIndex>[0]} options
  * @return {T | undefined}
  */
 export function useResponsiveValue(values, options = {}) {
 	const index = useBreakpointIndex(options);
 
-	if (!is.array(values) && !is.function(values)) return values;
+	if (!is.array(values) && typeof values !== 'function') return values;
 
 	let array = values || [];
-	if (is.function(values)) {
+	if (typeof values === 'function') {
 		array = values();
 	}
 

--- a/packages/styles/src/mixins/flow.js
+++ b/packages/styles/src/mixins/flow.js
@@ -48,7 +48,7 @@ export function flow(...args) {
 		if (is.number(arg) || is.string(arg)) {
 			results.push(arg);
 		}
-		if (is.array(arg)) {
+		if (Array.isArray(arg)) {
 			results.push(flow(...arg), ',');
 		}
 	}

--- a/packages/styles/src/mixins/flow.js
+++ b/packages/styles/src/mixins/flow.js
@@ -45,7 +45,7 @@ export function flow(...args) {
 	const results = [];
 
 	for (const arg of args) {
-		if (is.number(arg) || is.string(arg)) {
+		if (is.number(arg) || typeof arg === 'string') {
 			results.push(arg);
 		}
 		if (Array.isArray(arg)) {

--- a/packages/styles/src/mixins/transforms.js
+++ b/packages/styles/src/mixins/transforms.js
@@ -8,7 +8,7 @@ import { toPx } from './units';
  * @return {value is string | number}
  */
 function isValidOffset(value) {
-	return is.number(value) || is.string(value);
+	return is.number(value) || typeof value === 'string';
 }
 
 /**

--- a/packages/styles/src/mixins/z-index.js
+++ b/packages/styles/src/mixins/z-index.js
@@ -22,7 +22,7 @@ export function getZIndex(namespace, fallback) {
 		return namespace;
 	}
 	// Quick return for invalid namespaces
-	if (!is.string(namespace)) {
+	if (typeof namespace !== 'string') {
 		return fallback;
 	}
 

--- a/packages/styles/src/theme/create-theme.js
+++ b/packages/styles/src/theme/create-theme.js
@@ -12,7 +12,7 @@ const baseTheme = Object.freeze(Object.assign({}, config));
  * @return {Record<string, string>}
  */
 export function createTheme(callback) {
-	if (!is.function(callback)) return {};
+	if (typeof callback !== 'function') return {};
 
 	const props = {
 		get,

--- a/packages/utils/src/colors.js
+++ b/packages/utils/src/colors.js
@@ -1,6 +1,5 @@
 import colorize from 'tinycolor2';
 
-import { is } from './is';
 import { memoize } from './memoize';
 
 /**
@@ -38,7 +37,7 @@ function getColorComputationNode() {
  * @return {boolean} Whether the value is a valid color.
  */
 export function isColor(value) {
-	if (!is.string(value)) return false;
+	if (typeof value !== 'string') return false;
 	const test = colorize(value);
 
 	return test.isValid();
@@ -53,7 +52,7 @@ export function isColor(value) {
  * @return {string} The computed background color.
  */
 function __getComputedBackgroundColor(color) {
-	if (!is.string(color)) return '';
+	if (typeof color !== 'string') return '';
 
 	if (isColor(color)) return color;
 
@@ -92,7 +91,7 @@ export const getComputedBackgroundColor = memoize(__getComputedBackgroundColor);
  * @return {string} The computed text color.
  */
 function __getComputedColor(color) {
-	if (!is.string(color)) return '';
+	if (typeof color !== 'string') return '';
 
 	if (isColor(color)) return color;
 

--- a/packages/utils/src/event-handlers.js
+++ b/packages/utils/src/event-handlers.js
@@ -1,9 +1,4 @@
 /**
- * Internal dependencies
- */
-import { is } from './is';
-
-/**
  * Merges event handlers together.
  *
  * @template TEvent
@@ -15,10 +10,10 @@ export function mergeEvent(handler, otherHandler) {
 		/** @type {TEvent} */
 		event,
 	) => {
-		if (is.function(handler)) {
+		if (typeof handler === 'function') {
 			handler(event);
 		}
-		if (is.function(otherHandler)) {
+		if (typeof otherHandler === 'function') {
 			otherHandler(event);
 		}
 	};
@@ -35,7 +30,7 @@ export function mergeEventHandlers(handlers = {}, extraHandlers = {}) {
 	const mergedHandlers = { ...handlers };
 
 	for (const [key, handler] of Object.entries(mergedHandlers)) {
-		if (is.function(extraHandlers[key])) {
+		if (typeof extraHandlers[key] === 'function') {
 			mergedHandlers[key] = mergeEvent(handler, extraHandlers[key]);
 		}
 	}

--- a/packages/utils/src/hooks/use-media-query.js
+++ b/packages/utils/src/hooks/use-media-query.js
@@ -1,7 +1,6 @@
 import { noop } from 'lodash';
 import { useEffect, useState } from 'react';
 
-import { is } from '../is';
 import { json2mq } from '../media-queries';
 
 // For SSR
@@ -34,7 +33,7 @@ export function useMediaQuery(query, defaultMatches = true) {
 
 	useEffect(() => {
 		const mediaQueryList = matchMedia(
-			is.string(query) ? query : json2mq(query),
+			typeof query === 'string' ? query : json2mq(query),
 		);
 		let active = true;
 

--- a/packages/utils/src/media-queries.js
+++ b/packages/utils/src/media-queries.js
@@ -72,7 +72,7 @@ function obj2mq(obj = {}) {
  */
 export function json2mq(query) {
 	let mq = '';
-	if (is.string(query)) {
+	if (typeof query === 'string') {
 		return query;
 	}
 	// Handling array of media queries

--- a/packages/utils/src/react.js
+++ b/packages/utils/src/react.js
@@ -1,7 +1,5 @@
 import { Children, isValidElement } from 'react';
 
-import { is } from './is';
-
 /**
  * Merges React `ref` together.
  */
@@ -21,7 +19,7 @@ export { default as hoistNonReactStatics } from 'hoist-non-react-statics';
  * @return {import('react').ReactNodeArray} An array of available children.
  */
 export function getValidChildren(children) {
-	if (is.string(children)) return [children];
+	if (typeof children === 'string') return [children];
 
 	return Children.toArray(children).filter((child) => isValidElement(child));
 }
@@ -34,9 +32,10 @@ export function getValidChildren(children) {
  * @return {string} The display name of the Component / tagName.
  */
 export function getDisplayName(tagName) {
-	const displayName = is.string(tagName)
-		? tagName
-		: tagName.displayName || tagName.name || 'Component';
+	const displayName =
+		typeof tagName === 'string'
+			? tagName
+			: tagName.displayName || tagName.name || 'Component';
 
 	return displayName;
 }

--- a/packages/utils/src/react.js
+++ b/packages/utils/src/react.js
@@ -49,7 +49,7 @@ export function getDisplayName(tagName) {
  * @return {boolean} True, if children is a render function prop.
  */
 export function isRenderProp(children) {
-	return is.function(children);
+	return typeof children === 'function';
 }
 
 /**

--- a/packages/utils/src/unit-values.js
+++ b/packages/utils/src/unit-values.js
@@ -36,7 +36,7 @@ export const getParsedCSSValue = (initialValue) => {
  * @return {boolean} Whether the value is a valid CSS value.
  */
 export const isValidCSSValueForProp = (prop, value) => {
-	if (!is.string(prop)) return true;
+	if (typeof prop !== 'string') return true;
 
 	const computedStyleMap = getComputedStyledMap();
 
@@ -171,7 +171,7 @@ export function parseUnitValue(initialValue) {
  * @return {string} The unit value.
  */
 export function createUnitValue(value, unit) {
-	if (!unit || !is.string(unit) || !is.numeric(value)) {
+	if (!unit || typeof unit !== 'string' || !is.numeric(value)) {
 		return value.toString();
 	}
 

--- a/packages/utils/src/validation.js
+++ b/packages/utils/src/validation.js
@@ -1,9 +1,4 @@
 /**
- * Internal dependencies
- */
-import { is } from './is';
-
-/**
  * Merges validation functions together.
  *
  * @template {unknown[]} TArgs
@@ -13,8 +8,8 @@ import { is } from './is';
  * @return {Function | undefined} A single merged validation function.
  */
 export function mergeValidationFunctions(validate, extraValidate) {
-	if (!is.function(validate)) return;
-	if (!is.function(extraValidate)) return validate;
+	if (typeof validate !== 'function') return;
+	if (typeof extraValidate !== 'function') return validate;
 
 	return (/** @type {TArgs} */ ...args) => {
 		return validate(...args) || extraValidate(...args);

--- a/packages/website/src/components/DefinitionPopover.js
+++ b/packages/website/src/components/DefinitionPopover.js
@@ -10,7 +10,6 @@ import {
   Text,
 } from "@wp-g2/components"
 import { styled, ui } from "@wp-g2/styles"
-import { is } from "@wp-g2/utils"
 import { graphql, Link, useStaticQuery } from "gatsby"
 import React, { useEffect, useRef, useState } from "react"
 
@@ -46,7 +45,7 @@ export function DefinitionPopover({ children }) {
 
   const isCurrentPage = currentPage && currentPage.includes(data?.fields?.slug)
 
-  if (!data || !is.string(children) || isCurrentPage || !canRender) {
+  if (!data || typeof children !== "string" || isCurrentPage || !canRender) {
     return <code ref={nodeRef}>{children}</code>
   }
 


### PR DESCRIPTION
In preparation of the migration, we can go ahead and refactor the usages of these is functions. I only did these three to prevent the PR from being too much to review.