### PR TITLE
UnitInput: Improve initial unit parsing handling to better serve values like "auto"

### DIFF
--- a/packages/components/src/UnitInput/UnitInput.utils.js
+++ b/packages/components/src/UnitInput/UnitInput.utils.js
@@ -1,4 +1,4 @@
-import { is } from '@wp-g2/utils';
+import { is, isValidCSSValueForProp, parseUnitValue } from '@wp-g2/utils';
 
 export const UNITS = ['px', '%', 'em', 'rem', 'vh', 'vw', 'vmin', 'vmax'];
 
@@ -17,3 +17,31 @@ export function findUnitMatchExact({ units = UNITS, value = '' }) {
 export const isPotentialUnitValue = (value) => {
 	return is.numeric(value) && Number(value) !== 0;
 };
+
+export function getInitialParsedUnitValue({ cssProp, value }) {
+	const [parsedValue, unit] = parseUnitValue(value);
+	const isUndefinedParsedValue =
+		!is.defined(parsedValue) || is.empty(parsedValue);
+
+	const evalutedValue = isUndefinedParsedValue ? value : parsedValue;
+
+	// Validation without cssProp
+	if (!cssProp) {
+		if (isUndefinedParsedValue) {
+			return [evalutedValue, undefined];
+		} else {
+			return [parsedValue, unit];
+		}
+	}
+
+	// Validation with cssProp
+	if (isValidCSSValueForProp(cssProp, value)) {
+		if (isUndefinedParsedValue) {
+			return [evalutedValue, undefined];
+		} else {
+			return [parsedValue, unit];
+		}
+	}
+
+	return [undefined, undefined];
+}

--- a/packages/components/src/UnitInput/__stories__/UnitInput.stories.js
+++ b/packages/components/src/UnitInput/__stories__/UnitInput.stories.js
@@ -67,7 +67,7 @@ const Everything = () => {
 };
 
 const Example = () => {
-	const [value, setValue] = React.useState('13px');
+	const [value, setValue] = React.useState('auto');
 
 	return (
 		<>

--- a/packages/components/src/UnitInput/useUnitInput.js
+++ b/packages/components/src/UnitInput/useUnitInput.js
@@ -10,7 +10,11 @@ import {
 } from '@wp-g2/utils';
 import React from 'react';
 
-import { findUnitMatchExact, isPotentialUnitValue } from './UnitInput.utils';
+import {
+	findUnitMatchExact,
+	getInitialParsedUnitValue,
+	isPotentialUnitValue,
+} from './UnitInput.utils';
 
 /**
  * @typedef UnitStore
@@ -47,7 +51,7 @@ import { findUnitMatchExact, isPotentialUnitValue } from './UnitInput.utils';
  */
 export function useUnitInput(props, ref) {
 	const { cssProp, arrows = false, onChange = noop, value } = props;
-	const [parsedValue, unit] = parseUnitValue(value);
+	const [parsedValue, unit] = getInitialParsedUnitValue({ cssProp, value });
 	const inputRef = React.useRef();
 
 	/** @type {UnitInputState} */


### PR DESCRIPTION
This update fixes the handling of values like `auto` for `UnitInput`. Previously, `auto` may be assigned as a `unit` value.

This is because of the unit parsing function as it attempts to split `${number}${unit}` into `[value,unit]`. Since `auto` doesn't start with a number, the unit parser thinks that `auto` is the unit.

The solution was to add some validation for the initial store state, taking into consideration the `cssProp`, if provided.