### PR TITLE
UnitInput: Fix parsing of initial unit to handle `0` and unit values like `0px`

### DIFF
--- a/packages/components/src/UnitInput/UnitInput.utils.js
+++ b/packages/components/src/UnitInput/UnitInput.utils.js
@@ -20,9 +20,8 @@ export const isPotentialUnitValue = (value) => {
 
 export function getInitialParsedUnitValue({ cssProp, value }) {
 	const [parsedValue, unit] = parseUnitValue(value);
-	const isUndefinedParsedValue =
-		!is.defined(parsedValue) || is.empty(parsedValue);
 
+	const isUndefinedParsedValue = is.valueEmpty(parsedValue);
 	const evalutedValue = isUndefinedParsedValue ? value : parsedValue;
 
 	// Validation without cssProp

--- a/packages/components/src/UnitInput/__stories__/UnitInput.stories.js
+++ b/packages/components/src/UnitInput/__stories__/UnitInput.stories.js
@@ -67,7 +67,7 @@ const Everything = () => {
 };
 
 const Example = () => {
-	const [value, setValue] = React.useState('auto');
+	const [value, setValue] = React.useState('0px');
 
 	return (
 		<>


### PR DESCRIPTION
<img width="631" alt="Screen Shot 2021-01-10 at 7 04 19 PM" src="https://user-images.githubusercontent.com/2322354/104139068-dafa1180-5376-11eb-8522-152d2684abfc.png">
