### PR TITLE
Fork Zustand (3.3.1) into @wp-g2/substate

### DIFF
--- a/packages/components/src/Accordion/useAccordion.js
+++ b/packages/components/src/Accordion/useAccordion.js
@@ -69,9 +69,9 @@ export function useAccordion(props) {
 		...otherProps
 	} = useContextSystem(props, 'Accordion');
 
-	/** @type {import('zustand').UseStore<AccordionStore>} */
+	/** @type {import('@wp-g2/substate').UseStore<AccordionStore>} */
 	const accordionStore = useSubState((
-		/** @type {import('zustand').SetState<AccordionStore>} */ set,
+		/** @type {import('@wp-g2/substate').SetState<AccordionStore>} */ set,
 	) => ({
 		// State
 		current: setCurrentState([], current),
@@ -123,7 +123,7 @@ export function useAccordion(props) {
 			!!accordionStore.getState().has(id),
 	}));
 
-	/** @type {import('zustand').UseStore<Store>} */
+	/** @type {import('@wp-g2/substate').UseStore<Store>} */
 	const store = useSubState(() => ({
 		// Actions
 		update: ({ id, visible = false }) => {

--- a/packages/components/src/TextInput/useTextInputState.js
+++ b/packages/components/src/TextInput/useTextInputState.js
@@ -147,7 +147,7 @@ const reducer = (state, action) => {
  * @property {() => boolean} getIsReverted
  */
 
-/** @typedef {import('zustand').UseStore<TextInputStore>} TextInputState */
+/** @typedef {import('@wp-g2/substate').UseStore<TextInputStore>} TextInputState */
 
 /**
  * @typedef Options

--- a/packages/components/src/TextInput/useTextInputState.utils.js
+++ b/packages/components/src/TextInput/useTextInputState.utils.js
@@ -5,7 +5,7 @@ import { useDrag } from 'react-use-gesture';
 
 import * as styles from './TextInput.styles';
 
-/** @typedef {import('zustand').UseStore<{
+/** @typedef {import('@wp-g2/substate').UseStore<{
 	isShiftKey: boolean;
 	shiftStep: number;
 	step: number;

--- a/packages/components/src/UnitInput/useUnitInput.js
+++ b/packages/components/src/UnitInput/useUnitInput.js
@@ -32,7 +32,7 @@ import {
  * @property {(value: string) => boolean} getIsValidCSSValue
  */
 
-/** @typedef {import('zustand').UseStore<UnitStore>} UnitInputState */
+/** @typedef {import('@wp-g2/substate').UseStore<UnitStore>} UnitInputState */
 
 /**
  * @typedef OwnProps

--- a/packages/context/src/context-system-provider.js
+++ b/packages/context/src/context-system-provider.js
@@ -12,7 +12,7 @@ export const useComponentsContext = () => useContext(ComponentsContext);
 
 /**
  * @template T
- * @typedef {import('zustand').UseStore<T>} State
+ * @typedef {import('@wp-g2/substate').UseStore<T>} State
  */
 
 /**
@@ -23,7 +23,7 @@ export const useComponentsContext = () => useContext(ComponentsContext);
  * @param {T} initialState
  */
 export const createContextSystemStore = (initialState) => {
-	/** @type {import('zustand').UseStore<{ context: T, setContext: (next: T) => void }>} */
+	/** @type {import('@wp-g2/substate').UseStore<{ context: T, setContext: (next: T) => void }>} */
 	const contextSystemStore = createStore((set) => ({
 		context: initialState,
 		setContext: (next) => {
@@ -68,7 +68,7 @@ export const useContextStoreContext = () => useContext(ContextStoreContext);
  * @returns {JSX.Element} A Provider wrapped component.
  */
 const _ContextSystemProvider = ({ children, value }) => {
-	/** @type {import('zustand').UseStore<{ context: T; setContext: (next: T) => void; }>} */
+	/** @type {import('@wp-g2/substate').UseStore<{ context: T; setContext: (next: T) => void; }>} */
 	const store = useContextSystemBridge({ value });
 	const contextValue = React.useMemo(() => ({ store }), [store]);
 

--- a/packages/create-styles/src/components/theme-provider/utils.js
+++ b/packages/create-styles/src/components/theme-provider/utils.js
@@ -136,7 +136,7 @@ export function useReducedMotionMode({
 
 /**
  * @param {string} initialTheme
- * @returns {import('zustand').UseStore<{ theme: string, setTheme: (next: string) => void }>}
+ * @returns {import('@wp-g2/substate').UseStore<{ theme: string, setTheme: (next: string) => void }>}
  */
 function createThemeStore(initialTheme = '') {
 	return createStore((set) => ({

--- a/packages/create-styles/src/hooks/use-reduced-motion.js
+++ b/packages/create-styles/src/hooks/use-reduced-motion.js
@@ -7,7 +7,7 @@ import { createStore } from '@wp-g2/substate';
  *
  * Ideally, you would interface with this store using the useReducedMotion hook.
  */
-/** @type {import('zustand').UseStore<{ isReducedMotion: boolean, setIsReducedMotion: (next: boolean) => void }>} */
+/** @type {import('@wp-g2/substate').UseStore<{ isReducedMotion: boolean, setIsReducedMotion: (next: boolean) => void }>} */
 export const useReducedMotionState = createStore((setState) => ({
 	isReducedMotion: false,
 	setIsReducedMotion: (/** @type {boolean} */ next) => {

--- a/packages/substate/package.json
+++ b/packages/substate/package.json
@@ -16,9 +16,6 @@
   },
   "author": "Jon Quach <hello@jonquach.com> (https://jonquach.com)",
   "license": "MIT",
-  "dependencies": {
-    "zustand": "^3.1.3"
-  },
   "peerDependencies": {
     "react": "^16.8.0",
     "react-dom": "^16.8.0"

--- a/packages/substate/src/index.js
+++ b/packages/substate/src/index.js
@@ -1,5 +1,5 @@
-export { default as createStore } from 'zustand';
-export { default as shallowCompare } from 'zustand/shallow';
-export { default as createBaseStore } from 'zustand/vanilla';
+export { default as createStore } from './zustand';
+export { default as shallowCompare } from './zustand/shallow';
+export { default as createBaseStore } from './zustand/vanilla';
 
 export * from './use-sub-state';

--- a/packages/substate/src/index.js
+++ b/packages/substate/src/index.js
@@ -1,5 +1,5 @@
 export { default as createStore } from './zustand';
 export { default as shallowCompare } from './zustand/shallow';
 export { default as createBaseStore } from './zustand/vanilla';
-
+export * from './zustand/types';
 export * from './use-sub-state';

--- a/packages/substate/src/use-sub-state.js
+++ b/packages/substate/src/use-sub-state.js
@@ -1,9 +1,10 @@
 import { useRef } from 'react';
-import createStore from 'zustand';
+
+import createStore from './zustand';
 
 /**
  * @template {Record<string | number | symbol, unknown>} TState
- * @param {import('zustand').StateCreator<TState> | import('zustand').StoreApi<TState>} createState
+ * @param {import('./zustand/types').StateCreator<TState> | import('./zustand/types').StoreApi<TState>} createState
  */
 export function useSubState(createState) {
 	return useRef(createStore(createState)).current;

--- a/packages/substate/src/zustand/README.md
+++ b/packages/substate/src/zustand/README.md
@@ -1,0 +1,10 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+-   [Zustand](#zustand)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+# Zustand
+
+> Forked from https://github.com/pmndrs/zustand/releases/tag/v3.3.1

--- a/packages/substate/src/zustand/index.js
+++ b/packages/substate/src/zustand/index.js
@@ -1,0 +1,130 @@
+import { useEffect, useLayoutEffect, useReducer, useRef } from 'react';
+
+import createImpl from './vanilla';
+export * from './vanilla';
+
+// For server-side rendering: https://github.com/react-spring/zustand/pull/34
+const useIsoLayoutEffect =
+	typeof window === 'undefined' ? useEffect : useLayoutEffect;
+
+/**
+ * @template {import('./types').State} TState
+ * @param {import('./types').StateCreator<TState> | import('./types').StoreApi<TState>} createState
+ *
+ * @returns {import('./types').UseStore<TState>}
+ */
+export default function create(createState) {
+	/**
+	 * @type {import('./types').StoreApi<TState>}
+	 */
+	const api =
+		typeof createState === 'function'
+			? createImpl(createState)
+			: createState;
+
+	/**
+	 * @template StateSlice
+	 * @type {any}
+	 * @param {import('./types').StateSelector<TState, StateSlice>} [selector]
+	 * @param {import('./types').EqualityChecker<StateSlice>} [equalityFn]
+	 */
+	const useStore = (
+		selector = /** @type {any} */ (api.getState),
+		equalityFn = Object.is,
+	) => {
+		const [, forceUpdate] = useReducer((c) => c + 1, 0);
+
+		const state = api.getState();
+		const stateRef = useRef(state);
+		const selectorRef = useRef(selector);
+		const equalityFnRef = useRef(equalityFn);
+		const erroredRef = useRef(false);
+
+		/**
+		 * @type {import('react').MutableRefObject<StateSlice | undefined>}
+		 */
+		const currentSliceRef = useRef();
+		if (currentSliceRef.current === undefined) {
+			currentSliceRef.current = selector(state);
+		}
+
+		/**
+		 * @type {StateSlice | undefined}
+		 */
+		let newStateSlice;
+		let hasNewStateSlice = false;
+
+		// The selector or equalityFn need to be called during the render phase if
+		// they change. We also want legitimate errors to be visible so we re-run
+		// them if they errored in the subscriber.
+		if (
+			stateRef.current !== state ||
+			selectorRef.current !== selector ||
+			equalityFnRef.current !== equalityFn ||
+			erroredRef.current
+		) {
+			// Using local variables to avoid mutations in the render phase.
+			newStateSlice = selector(state);
+			hasNewStateSlice = !equalityFn(
+				/** @type {StateSlice} */ (currentSliceRef.current),
+				/** @type {StateSlice} */ (newStateSlice),
+			);
+		}
+
+		// Syncing changes in useEffect.
+		useIsoLayoutEffect(() => {
+			if (hasNewStateSlice) {
+				currentSliceRef.current = /** @type {StateSlice} */ (newStateSlice);
+			}
+			stateRef.current = state;
+			selectorRef.current = selector;
+			equalityFnRef.current = equalityFn;
+			erroredRef.current = false;
+		});
+
+		const stateBeforeSubscriptionRef = useRef(state);
+		useIsoLayoutEffect(() => {
+			const listener = () => {
+				try {
+					const nextState = api.getState();
+					const nextStateSlice = selectorRef.current(nextState);
+					if (
+						!equalityFnRef.current(
+							/** @type {StateSlice} */ (currentSliceRef.current),
+							nextStateSlice,
+						)
+					) {
+						stateRef.current = nextState;
+						currentSliceRef.current = nextStateSlice;
+						forceUpdate();
+					}
+				} catch (error) {
+					erroredRef.current = true;
+					forceUpdate();
+				}
+			};
+			const unsubscribe = api.subscribe(listener);
+			if (api.getState() !== stateBeforeSubscriptionRef.current) {
+				listener(); // state has changed before subscription
+			}
+			return unsubscribe;
+		}, []);
+
+		return hasNewStateSlice
+			? /** @type {StateSlice} */ (newStateSlice)
+			: currentSliceRef.current;
+	};
+
+	Object.assign(useStore, api);
+
+	// For backward compatibility (No TS types for this)
+	useStore[Symbol.iterator] = function* () {
+		console.warn(
+			'[useStore, api] = create() is deprecated and will be removed in v4',
+		);
+		yield useStore;
+		yield api;
+	};
+
+	return useStore;
+}

--- a/packages/substate/src/zustand/middleware.js
+++ b/packages/substate/src/zustand/middleware.js
@@ -1,0 +1,199 @@
+/**
+ * @template {import('./types').State} S
+ * @template {{ type: unknown }} A
+ * @param {(state: S, action: A) => S} reducer
+ * @param {S} initial
+ *
+ * @return {import('./types').Redux<S,A>}
+ */
+export const redux = (reducer, initial) => (set, get, api) => {
+	api.dispatch = (/** @type {A} */ action) => {
+		set((/** @type {S} */ state) => reducer(state, action));
+		if (api.devtools) {
+			api.devtools.send(api.devtools.prefix + action.type, get());
+		}
+		return action;
+	};
+	return { dispatch: api.dispatch, ...initial };
+};
+
+/**
+ * @template {import('./types').State} S
+ * @param {import('./types').StateCreator<S, import('./types').NamedSet<S>>} fn
+ * @param {string} [prefix]
+ *
+ * @return {import('./types').DevTools<S>}
+ */
+export const devtools = (fn, prefix) => (set, get, api) => {
+	let extension;
+	try {
+		extension =
+			/** @type {any} */ (window).__REDUX_DEVTOOLS_EXTENSION__ ||
+			/** @type {any} */ (window).top.__REDUX_DEVTOOLS_EXTENSION__;
+		// eslint-disable-next-line
+	} catch {}
+
+	if (!extension) {
+		if (
+			process.env.NODE_ENV === 'development' &&
+			typeof window !== 'undefined'
+		) {
+			console.warn('Please install/enable Redux devtools extension');
+		}
+		api.devtools = null;
+		return fn(set, get, api);
+	}
+	/**
+	 * @type {import('./types').NamedSet<S>}
+	 */
+	const namedSet = (state, replace, name) => {
+		set(state, replace);
+		if (!api.dispatch) {
+			api.devtools.send(api.devtools.prefix + (name || 'action'), get());
+		}
+	};
+	const initialState = fn(namedSet, get, api);
+	if (!api.devtools) {
+		const savedSetState = api.setState;
+		api.setState = (
+			/** @type {import('./types').PartialState<S>} */ state,
+			/** @type {boolean | undefined} */ replace,
+		) => {
+			savedSetState(state, replace);
+			api.devtools.send(api.devtools.prefix + 'setState', api.getState());
+		};
+		api.devtools = extension.connect({ name: prefix });
+		api.devtools.prefix = prefix ? `${prefix} > ` : '';
+		api.devtools.subscribe((/** @type {any} */ message) => {
+			if (message.type === 'DISPATCH' && message.state) {
+				const ignoreState =
+					message.payload.type === 'JUMP_TO_ACTION' ||
+					message.payload.type === 'JUMP_TO_STATE';
+				if (!api.dispatch && !ignoreState) {
+					api.setState(JSON.parse(message.state));
+				} else {
+					savedSetState(JSON.parse(message.state));
+				}
+			} else if (
+				message.type === 'DISPATCH' &&
+				message.payload?.type === 'COMMIT'
+			) {
+				api.devtools.init(api.getState());
+			}
+		});
+		api.devtools.init(initialState);
+	}
+	return initialState;
+};
+
+/**
+ * @template {import('./types').State} PrimaryState
+ * @template {import('./types').State} SecondaryState
+ * @param {PrimaryState} initialState
+ * @param {import('./types').CombineCreate<PrimaryState, SecondaryState>} create
+ *
+ * @returns {import('./types').StateCreator<PrimaryState & SecondaryState>}
+ */
+export const combine = (initialState, create) => (set, get, api) =>
+	Object.assign(
+		{},
+		initialState,
+		create(
+			/** @type {import('./types').SetState<PrimaryState>} */ (set),
+			/** @type {import('./types').GetState<PrimaryState>} */ (get),
+			/** @type {import('./types').StoreApi<PrimaryState>} */ (api),
+		),
+	);
+
+/**
+ * @template {import('./types').State} S
+ * @param {import('./types').StateCreator<S>} config
+ * @param {import('./types').PersistOptions<S>} options
+ *
+ * @return {import('./types').StateCreator<S>}
+ */
+export const persist = (config, options) => (set, get, api) => {
+	const {
+		name,
+		getStorage = () => localStorage,
+		serialize = JSON.stringify,
+		deserialize = JSON.parse,
+		blacklist,
+		whitelist,
+		onRehydrateStorage,
+		version = 0,
+	} = options || {};
+
+	/**
+	 * @type {import('./types').StateStorage | undefined}
+	 */
+	let storage;
+
+	try {
+		storage = getStorage();
+	} catch (e) {
+		// prevent error if the storage is not defined (e.g. when server side rendering a page)
+	}
+
+	if (!storage) return config(set, get, api);
+
+	const setItem = async () => {
+		const state = { ...get() };
+
+		if (whitelist) {
+			Object.keys(state).forEach((key) => {
+				!whitelist.includes(key) && delete state[key];
+			});
+		}
+		if (blacklist) {
+			blacklist.forEach((key) => delete state[key]);
+		}
+
+		// eslint-disable-next-line
+		storage?.setItem(name, await serialize({ state, version }));
+	};
+
+	const savedSetState = api.setState;
+
+	api.setState = (state, replace) => {
+		savedSetState(state, replace);
+		setItem();
+	};
+
+	// rehydrate initial state with existing stored state
+	(async () => {
+		const postRehydrationCallback =
+			onRehydrateStorage?.(get()) || undefined;
+
+		try {
+			const storageValue = await storage.getItem(name);
+
+			if (storageValue) {
+				const deserializedStorageValue = await deserialize(
+					storageValue,
+				);
+
+				// if versions mismatch, clear storage by storing the new initial state
+				if (deserializedStorageValue.version !== version) {
+					setItem();
+				} else {
+					set(deserializedStorageValue.state);
+				}
+			}
+		} catch (e) {
+			throw new Error(`Unable to get to stored state in "${name}"`);
+		} finally {
+			// eslint-disable-next-line
+			postRehydrationCallback?.(get());
+		}
+	})();
+
+	return config(
+		(payload) => {
+			set(payload);
+			setItem();
+		},
+		get,
+		api,
+	);
+};

--- a/packages/substate/src/zustand/shallow.js
+++ b/packages/substate/src/zustand/shallow.js
@@ -1,0 +1,41 @@
+/**
+ * @typedef {Record<string | number | symbol, unknown>} Obj
+ */
+
+/**
+ * @template {any}T
+ * @template {any}U
+ *
+ * @param {T} objA
+ * @param {U} objB
+ */
+export default function shallow(objA, objB) {
+	if (Object.is(objA, objB)) {
+		return true;
+	}
+	if (
+		typeof objA !== 'object' ||
+		objA === null ||
+		typeof objB !== 'object' ||
+		objB === null
+	) {
+		return false;
+	}
+
+	const keysA = Object.keys(/** @type {object} */ (objA));
+	if (keysA.length !== Object.keys(/** @type {object} */ (objB)).length) {
+		return false;
+	}
+	for (let i = 0; i < keysA.length; i++) {
+		if (
+			!Object.prototype.hasOwnProperty.call(objB, keysA[i]) ||
+			!Object.is(
+				/** @type {Obj} */ (objA)[keysA[i]],
+				/** @type {Obj} */ (objB)[keysA[i]],
+			)
+		) {
+			return false;
+		}
+	}
+	return true;
+}

--- a/packages/substate/src/zustand/types.ts
+++ b/packages/substate/src/zustand/types.ts
@@ -1,0 +1,124 @@
+export type State = Record<string | number | symbol, unknown>;
+export type PartialState<T extends State> =
+	| Partial<T>
+	| ((state: T) => Partial<T>);
+export type StateSelector<T extends State, U> = (state: T) => U;
+export type EqualityChecker<T> = (state: T, newState: T) => boolean;
+export type StateListener<T> = (state: T, previousState: T) => void;
+export type StateSliceListener<T> = (slice: T, previousSlice: T) => void;
+export interface Subscribe<T extends State> {
+	(listener: StateListener<T>): () => void;
+	<StateSlice>(
+		listener: StateSliceListener<StateSlice>,
+		selector: StateSelector<T, StateSlice>,
+		equalityFn?: EqualityChecker<StateSlice>,
+	): () => void;
+}
+export type SetState<T extends State> = (
+	partial: PartialState<T>,
+	replace?: boolean,
+) => void;
+export type GetState<T extends State> = () => T;
+export type Destroy = () => void;
+export interface StoreApi<T extends State> {
+	setState: SetState<T>;
+	getState: GetState<T>;
+	subscribe: Subscribe<T>;
+	destroy: Destroy;
+}
+export type StateCreator<T extends State, CustomSetState = SetState<T>> = (
+	set: CustomSetState,
+	get: GetState<T>,
+	api: StoreApi<T>,
+) => T;
+
+export type Redux<S extends State, A extends { type: unknown }> = (
+	set: SetState<S>,
+	get: GetState<S>,
+	api: StoreApi<S> & {
+		dispatch?: (a: A) => A;
+		devtools?: any;
+	},
+) => S & { dispatch: (a: A) => A };
+
+export type NamedSet<S extends State> = (
+	partial: PartialState<S>,
+	replace?: boolean,
+	name?: string,
+) => void;
+
+export type DevTools<S extends State> = (
+	set: SetState<S>,
+	get: GetState<S>,
+	api: StoreApi<S> & { dispatch?: unknown; devtools?: any },
+) => S;
+
+export type CombineCreate<
+	PrimaryState extends State,
+	SecondaryState extends State
+> = (
+	set: SetState<PrimaryState>,
+	get: GetState<PrimaryState>,
+	api: StoreApi<PrimaryState>,
+) => SecondaryState;
+
+export type StateStorage = {
+	getItem: (name: string) => string | null | Promise<string | null>;
+	setItem: (name: string, value: string) => void | Promise<void>;
+};
+type StorageValue<S> = { state: S; version: number };
+
+export type PersistOptions<S> = {
+	/** Name of the storage (must be unique) */
+	name: string;
+	/**
+	 * A function returning a storage.
+	 * The storage must fit `window.localStorage`'s api (or an async version of it).
+	 * For example the storage could be `AsyncStorage` from React Native.
+	 *
+	 * @default () => localStorage
+	 */
+	getStorage?: () => StateStorage;
+	/**
+	 * Use a custom serializer.
+	 * The returned string will be stored in the storage.
+	 *
+	 * @default JSON.stringify
+	 */
+	serialize?: (state: StorageValue<S>) => string | Promise<string>;
+	/**
+	 * Use a custom deserializer.
+	 *
+	 * @param str The storage's current value.
+	 * @default JSON.parse
+	 */
+	deserialize?: (str: string) => StorageValue<S> | Promise<S>;
+	/**
+	 * Prevent some items from being stored.
+	 */
+	blacklist?: (keyof S)[];
+	/**
+	 * Only store the listed properties.
+	 */
+	whitelist?: (keyof S)[];
+	/**
+	 * A function returning another (optional) function.
+	 * The main function will be called before the storage rehydration.
+	 * The returned function will be called after the storage rehydration.
+	 */
+	onRehydrateStorage?: (state: S) => ((state: S) => void) | void;
+	/**
+	 * If the stored state's version mismatch the one specified here, the storage will not be used.
+	 * This is useful when adding a breaking change to your store.
+	 */
+	version?: number;
+};
+
+export interface UseStore<T extends State> {
+	(): T;
+	<U>(selector: StateSelector<T, U>, equalityFn?: EqualityChecker<U>): U;
+	setState: SetState<T>;
+	getState: GetState<T>;
+	subscribe: Subscribe<T>;
+	destroy: Destroy;
+}

--- a/packages/substate/src/zustand/vanilla.js
+++ b/packages/substate/src/zustand/vanilla.js
@@ -1,0 +1,85 @@
+/**
+ * @template {import('./types').State}TState
+ * @param {import('./types').StateCreator<TState>} createState
+ *
+ * @returns {import('./types').StoreApi<TState>}
+ */
+export default function create(createState) {
+	/** @type {TState} */
+	let state;
+	/** @type {Set<import('./types').StateListener<TState>>} */
+	const listeners = new Set();
+
+	/** @type {import('./types').SetState<TState>} */
+	const setState = (partial, replace) => {
+		const nextState =
+			typeof partial === 'function' ? partial(state) : partial;
+		if (nextState !== state) {
+			const previousState = state;
+			state = replace
+				? /** @type {TState} */ (nextState)
+				: Object.assign({}, state, nextState);
+			listeners.forEach((listener) => listener(state, previousState));
+		}
+	};
+
+	/** @type {import('./types').GetState<TState>} */
+	const getState = () => state;
+
+	/**
+	 * @template StateSlice
+	 * @param {import('./types').StateSliceListener<StateSlice>} listener
+	 * @param {import('./types').StateSelector<TState, StateSlice>} selector
+	 * @param {import('./types').EqualityChecker<StateSlice>} equalityFn
+	 */
+	const subscribeWithSelector = (
+		listener,
+		selector = /** @type {any} */ (getState),
+		equalityFn = Object.is,
+	) => {
+		/** @type {StateSlice} */
+		let currentSlice = selector(state);
+		function listenerToAdd() {
+			const nextSlice = selector(state);
+			if (!equalityFn(currentSlice, nextSlice)) {
+				const previousSlice = currentSlice;
+				listener((currentSlice = nextSlice), previousSlice);
+			}
+		}
+		listeners.add(listenerToAdd);
+		// Unsubscribe
+		return () => listeners.delete(listenerToAdd);
+	};
+
+	/**
+	 * @template StateSlice
+	 * @param {import('./types').StateListener<StateSlice> | import('./types').StateSliceListener<StateSlice> } listener
+	 * @param {import('./types').StateSelector<TState, StateSlice>} [selector]
+	 * @param {import('./types').EqualityChecker<StateSlice>} [equalityFn]
+	 */
+	const subscribe = (listener, selector, equalityFn) => {
+		if (selector || equalityFn) {
+			return subscribeWithSelector(
+				/** @type {import('./types').StateSliceListener<StateSlice>} */ (listener),
+				selector,
+				equalityFn,
+			);
+		}
+		listeners.add(
+			/** @type {import('./types').StateListener<TState>} */ (listener),
+		);
+		// Unsubscribe
+		return () =>
+			listeners.delete(
+				/** @type {import('./types').StateListener<TState>} */ (listener),
+			);
+	};
+
+	/**
+	 * @type {import('./types').Destroy}
+	 */
+	const destroy = () => listeners.clear();
+	const api = { setState, getState, subscribe, destroy };
+	state = createState(setState, getState, api);
+	return api;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -25495,10 +25495,10 @@ yurnalist@^1.1.2:
     strip-ansi "^5.2.0"
     strip-bom "^4.0.0"
 
-zustand@^3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/zustand/-/zustand-3.1.3.tgz#33df7f56ec11b3003458b60606addc94225b282c"
-  integrity sha512-Otuzh3r0GsatvsUWeXEwdYjZEw1TItWcAXwDGEHdXE4/k6WbAdVDxC21t/Poq4ZMB+2VaQNKICWu7eCBUJ65tQ==
+zustand@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/zustand/-/zustand-3.3.1.tgz#de5c4b51112b84e0f819d8b3f336fbfbc087d758"
+  integrity sha512-o0rgrBsi29nCkPHdhtkAHisCIlmRUoXOV+1AmDMeCgkGG0i5edFSpGU0KiZYBvFmBYycnck4Z07JsLYDjSET9g==
 
 zwitch@^1.0.0:
   version "1.0.5"


### PR DESCRIPTION
This update forks [zustand @3.3.1](https://github.com/pmndrs/zustand/releases/tag/v3.3.1) into `@wp-g2/substate` to make the library compatible with Gutenberg.

A big thanks to @saramarcondes for walking me through this update and teaching me how to **TYPE**!