### PR TITLE
Context System: Refactor substate

### DIFF
--- a/packages/context/src/__stories__/ComponentsProvider.stories.js
+++ b/packages/context/src/__stories__/ComponentsProvider.stories.js
@@ -1,19 +1,52 @@
-import { Card, CardBody, Text } from '@wp-g2/components';
+import { Card, CardBody, Text, View } from '@wp-g2/components';
 import { ui } from '@wp-g2/styles';
 import React from 'react';
 
 import { ContextSystemProvider } from '../index';
+
+const SomeContext = React.createContext();
+const useSomeContext = () => React.useContext(SomeContext);
 
 export default {
 	component: ContextSystemProvider,
 	title: 'Context/ContextSystemProvider',
 };
 
-export const _default = () => {
+const innerContext = {
+	Card: {
+		css: {
+			background: 'white',
+		},
+	},
+};
+
+const InnerContent = React.memo(() => {
+	const state = useSomeContext();
+	const isEven = state % 2 === 0;
+	const style = isEven ? { background: 'red' } : null;
+	return <View css={style}>{state}</View>;
+});
+
+const InnerCard = React.memo(() => {
+	return (
+		<View css={{ padding: 40 }}>
+			<Card>
+				<CardBody css={[{ border: '3px solid green' }]}>
+					<InnerContent />
+				</CardBody>
+			</Card>
+		</View>
+	);
+});
+
+export const Default = () => {
+	const [state, update] = React.useState(0);
+	const forceUpdate = () => update((prev) => prev + 1);
+
 	const value = {
 		Card: {
 			css: {
-				background: 'blue',
+				background: state % 2 === 0 ? 'blue' : 'yellow',
 			},
 		},
 		CardBody: {
@@ -31,18 +64,24 @@ export const _default = () => {
 
 	return (
 		<>
-			<ContextSystemProvider value={value}>
+			<SomeContext.Provider value={state}>
+				<button onClick={forceUpdate}>Force Update</button>
+				<ContextSystemProvider value={value}>
+					<Card>
+						<CardBody css={[{ border: '3px solid green' }]}>
+							<Text optimizeReadabilityFor="blue">Card</Text>
+							<ContextSystemProvider value={innerContext}>
+								<InnerCard />
+							</ContextSystemProvider>
+						</CardBody>
+					</Card>
+				</ContextSystemProvider>
 				<Card>
-					<CardBody css={[{ border: '3px solid green' }]}>
-						<Text optimizeReadabilityFor="blue">Card</Text>
+					<CardBody>
+						<Text>Card</Text>
 					</CardBody>
 				</Card>
-			</ContextSystemProvider>
-			<Card>
-				<CardBody>
-					<Text>Card</Text>
-				</CardBody>
-			</Card>
+			</SomeContext.Provider>
 		</>
 	);
 };

--- a/packages/context/src/__tests__/__snapshots__/context-system-provider.test.js.snap
+++ b/packages/context/src/__tests__/__snapshots__/context-system-provider.test.js.snap
@@ -29,17 +29,26 @@ exports[`props should render correctly 1`] = `
 `;
 
 exports[`props should render css props + provided css 1`] = `
-<div
-  class="components-olaf wp-components-olaf olaf css-y278hy"
-  data-g2-c16t="true"
-  data-g2-component="Olaf"
-/>
+<div>
+  <div
+    class="components-olaf wp-components-olaf olaf css-w4hnsq"
+    data-g2-c16t="true"
+    data-g2-component="Olaf"
+  />
+</div>
 `;
 
 exports[`props should render css props 1`] = `
-<div
-  class="components-olaf wp-components-olaf olaf css-er5ts4"
-  data-g2-c16t="true"
-  data-g2-component="Olaf"
-/>
+<div>
+  <div
+    class="components-olaf wp-components-olaf olaf css-hs2bux"
+    data-g2-c16t="true"
+    data-g2-component="Olaf"
+  />
+  <div
+    class="components-olaf wp-components-olaf olaf css-1nqjm19"
+    data-g2-c16t="true"
+    data-g2-component="Olaf"
+  />
+</div>
 `;

--- a/packages/context/src/__tests__/context-system-provider.test.js
+++ b/packages/context/src/__tests__/context-system-provider.test.js
@@ -78,10 +78,17 @@ describe('props', () => {
 
 		const [first, second] = [...container.querySelectorAll('.olaf')];
 
-		expect(container.firstChild).toMatchSnapshot();
+		expect(container).toMatchSnapshot();
 
 		const firstCSS = first.classList.toString();
 		const secondCSS = second.classList.toString();
+
+		expect(first).toHaveStyle(`background: white`);
+		expect(first).toHaveStyle(`padding: 20px`);
+
+		expect(second).not.toHaveStyle(`background: white`);
+		expect(second).not.toHaveStyle(`padding: 20px`);
+
 		expect(firstCSS).not.toEqual(secondCSS);
 	});
 
@@ -116,10 +123,11 @@ describe('props', () => {
 			</>,
 		);
 
-		expect(container.firstChild).toMatchSnapshot();
+		expect(container).toMatchSnapshot();
 
 		const el = container.querySelector('.olaf');
 
+		expect(el).toHaveStyle(`border: 2px solid blue`);
 		expect(el).toHaveStyle(`background: white`);
 		expect(el).toHaveStyle(`font-weight: bold`);
 	});

--- a/packages/context/src/context-system-provider.js
+++ b/packages/context/src/context-system-provider.js
@@ -5,6 +5,13 @@ import React, { createContext, useContext, useRef } from 'react';
 export const ComponentsContext = createContext({});
 export const useComponentsContext = () => useContext(ComponentsContext);
 
+/**
+ * Consolidates incoming ContextSystem values with a (potential) parent ContextSystem value.
+ *
+ * @param {object} props
+ * @param {object} props.value
+ * @return {object}
+ */
 function useContextSystemBridge({ value }) {
 	if (isNil(value)) {
 		// @ts-ignore
@@ -45,7 +52,7 @@ function useContextSystemBridge({ value }) {
  * @param {T} options.value Props to render into connected components.
  * @returns {JSX.Element} A Provider wrapped component.
  */
-const _ContextSystemProvider = ({ children, value }) => {
+const BaseContextSystemProvider = ({ children, value }) => {
 	const contextValue = useContextSystemBridge({ value });
 
 	return (
@@ -55,4 +62,4 @@ const _ContextSystemProvider = ({ children, value }) => {
 	);
 };
 
-export const ContextSystemProvider = React.memo(_ContextSystemProvider);
+export const ContextSystemProvider = React.memo(BaseContextSystemProvider);

--- a/packages/context/src/context-system-provider.js
+++ b/packages/context/src/context-system-provider.js
@@ -1,6 +1,6 @@
 import { deepEqual, deepMerge, useIsomorphicLayoutEffect } from '@wp-g2/utils';
 import { isNil } from 'lodash';
-import React, { createContext, useContext, useRef } from 'react';
+import React, { createContext, useContext, useRef, useState } from 'react';
 
 export const ComponentsContext = createContext({});
 export const useComponentsContext = () => useContext(ComponentsContext);
@@ -21,18 +21,28 @@ function useContextSystemBridge({ value }) {
 	const parentContextRef = useRef(parentContext);
 	const valueRef = useRef(deepMerge(parentContext, value));
 
+	const [config, setConfig] = useState(valueRef.current);
+
 	useIsomorphicLayoutEffect(() => {
+		let hasChange = false;
+
 		if (!deepEqual(value, valueRef.current)) {
 			valueRef.current = value;
+			hasChange = true;
 		}
 
 		if (!deepEqual(parentContext, parentContextRef.current)) {
 			valueRef.current = deepMerge(parentContext, valueRef.current);
 			parentContextRef.current = parentContext;
+			hasChange = true;
+		}
+
+		if (hasChange) {
+			setConfig((prev) => ({ ...prev, ...valueRef.current }));
 		}
 	}, [value, parentContext]);
 
-	return valueRef.current;
+	return config;
 }
 
 /**

--- a/packages/context/src/use-context-system.js
+++ b/packages/context/src/use-context-system.js
@@ -1,10 +1,9 @@
 import { css, cx } from '@wp-g2/styles';
-import { shallowCompare } from '@wp-g2/substate';
 import { memoize } from '@wp-g2/utils';
 import { kebabCase, uniq } from 'lodash';
 
 import { CONNECTED_NAMESPACE } from './constants';
-import { useContextStoreContext } from './context-system-provider';
+import { useComponentsContext } from './context-system-provider';
 import { ns } from './utils';
 
 /**
@@ -22,13 +21,10 @@ import { ns } from './utils';
  * @return {ConnectedProps<P>}
  */
 export function useContextSystem(props, namespace) {
-	const { store: useStore } = useContextStoreContext();
+	const contextSystemProps = useComponentsContext();
 	const displayName = Array.isArray(namespace) ? namespace[0] : namespace;
 
-	const contextProps = useStore(
-		(state) => state?.context?.[displayName] || {},
-		shallowCompare,
-	);
+	const contextProps = contextSystemProps?.[displayName] || {};
 
 	/** @type {ConnectedProps<P>} */
 	// @ts-ignore We fill in the missing properties below


### PR DESCRIPTION
This update refactors the ContextSystem to use default React hooks for config/render management rather than Zustand.