### PR TITLE
Packages: Align reakit dependency with WordPress packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@wordpress/i18n": "^3.17.0",
     "@wordpress/icons": "^2.9.0",
     "@wordpress/is-shallow-equal": "^3.0.0",
+    "@wordpress/warning": "^1.3.0",
     "among": "2.0.0",
     "babel-loader": "^8.1.0",
     "eslint-config-prettier": "6.11.0",
@@ -91,7 +92,6 @@
     "prettier": "^2.1.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
-    "reakit-warning": "0.4.1",
     "typescript": "^4.0.5",
     "yup": "0.29.3",
     "zustand": "^3.3.1"

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -30,7 +30,7 @@
     "react-colorful": "4.4.4",
     "react-textarea-autosize": "^8.2.0",
     "react-use-gesture": "^9.0.0",
-    "reakit": "1.1.0"
+    "reakit": "^1.3.4"
   },
   "devDependencies": {
     "@emotion/jest": "^11.0.0",

--- a/packages/create-styles/package.json
+++ b/packages/create-styles/package.json
@@ -34,7 +34,7 @@
     "react-dom": "^16.13.1"
   },
   "devDependencies": {
-    "reakit-utils": "^0.15.0"
+    "reakit-utils": "^0.15.1"
   },
   "gitHead": "9536f69d764f89429aa66f4368914ea7936ca4c7"
 }

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -20,6 +20,7 @@
         "@wp-g2/utils": "^0.0.140"
     },
     "peerDependencies": {
+        "@wordpress/warning": ">=1.3",
         "react": "^16.13.1",
         "react-dom": "^16.13.1"
     },

--- a/packages/styles/src/presets/get.js
+++ b/packages/styles/src/presets/get.js
@@ -1,4 +1,4 @@
-import { warning } from '@wp-g2/utils';
+import warning from '@wordpress/warning';
 
 import { get } from '../core';
 export { get } from '../core';
@@ -11,12 +11,10 @@ export function getTokenValue(token) {
 		.getPropertyValue(cssVariable);
 
 	warning(
-		true,
-		'@wp-g2/styles, ui.getTokenValue',
-		`❗️This function is for debugging only.`,
-		`The "${token}" value is a live CSS variable, and cannot be reliably depended upon.`,
-		'',
-		`ui.getTokenValue('${token}') = ${rawValue};`,
+		`@wp-g2/styles, ui.getTokenValue
+❗️This function is for debugging only.
+The "${token}" value is a live CSS variable, and cannot be reliably depended upon.
+ui.getTokenValue('${token}') = ${rawValue};`,
 	);
 
 	return rawValue;

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -26,7 +26,6 @@
         "memize": "^1.1.0",
         "react-merge-refs": "^1.1.0",
         "react-resize-aware": "^3.1.0",
-        "reakit-warning": "^0.5.5",
         "tinycolor2": "^1.4.2",
         "use-enhanced-state": "^0.0.13",
         "use-isomorphic-layout-effect": "^1.0.0"

--- a/packages/utils/src/index.js
+++ b/packages/utils/src/index.js
@@ -17,4 +17,3 @@ export * from './simple-equal';
 export * from './unit-values';
 export * from './validation';
 export * from './values';
-export * from './warning';

--- a/packages/utils/src/warning.js
+++ b/packages/utils/src/warning.js
@@ -1,1 +1,0 @@
-export * from 'reakit-warning';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3952,15 +3952,15 @@
     schema-utils "^2.6.5"
     source-map "^0.7.3"
 
-"@popperjs/core@^2.4.2", "@popperjs/core@^2.5.4":
-  version "2.5.4"
-  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.5.4.tgz#de25b5da9f727985a3757fd59b5d028aba75841a"
-  integrity sha512-ZpKr+WTb8zsajqgDkvCEWgp6d5eJT6Q63Ng2neTbzBO76Lbe91vX/iVIW9dikq+Fs3yEo+ls4cxeXABD2LtcbQ==
-
 "@popperjs/core@^2.4.4":
   version "2.5.3"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.5.3.tgz#4982b0b66b7a4cf949b86f5d25a8cf757d3cfd9d"
   integrity "sha1-SYKwtmt6TPlJuG9dJajPdX08/Z0= sha512-RFwCobxsvZ6j7twS7dHIZQZituMIDJJNHS/qY6iuthVebxS3zhRY+jaC2roEKiAYaVuTcGmX6Luc6YBcf6zJVg=="
+
+"@popperjs/core@^2.5.4":
+  version "2.5.4"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.5.4.tgz#de25b5da9f727985a3757fd59b5d028aba75841a"
+  integrity sha512-ZpKr+WTb8zsajqgDkvCEWgp6d5eJT6Q63Ng2neTbzBO76Lbe91vX/iVIW9dikq+Fs3yEo+ls4cxeXABD2LtcbQ==
 
 "@reach/alert@0.10.3":
   version "0.10.3"
@@ -5817,6 +5817,11 @@
     lodash "^4.17.19"
     rungen "^0.3.2"
 
+"@wordpress/warning@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/warning/-/warning-1.3.0.tgz#9254f77b0cc79b1b356c93d2b726be78d82588ad"
+  integrity sha512-xwvgwqugc3zQawSPMMA09knAgap7IGgp0PxTXpFqizGFRIohoXFWERnPBZT0VsSCovqYS0ADcH+ZZgQ+BKAzLA==
+
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"
@@ -7285,7 +7290,7 @@ body-parser@1.19.0, body-parser@^1.19.0:
     raw-body "2.4.0"
     type-is "~1.6.17"
 
-body-scroll-lock@^3.0.2:
+body-scroll-lock@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/body-scroll-lock/-/body-scroll-lock-3.1.5.tgz#c1392d9217ed2c3e237fee1e910f6cdd80b7aaec"
   integrity sha512-Yi1Xaml0EvNA0OYWxXiYNqY24AfWkbA6w5vxE7GWxtKfzIbZM+Qw+aSmkgsbWzbHiy/RCSkUZBplVxTA+E4jJg==
@@ -20748,52 +20753,35 @@ readdirp@~3.4.0:
   dependencies:
     picomatch "^2.2.1"
 
-reakit-system@^0.13.0:
-  version "0.13.1"
-  resolved "https://registry.yarnpkg.com/reakit-system/-/reakit-system-0.13.1.tgz#e756b9a1b9d6cfe75f9a5e77531e5b0f9eb8227b"
-  integrity sha512-qglfQ53FsJh5+VSkjMtBg7eZiowj9zXOyfJJxfaXh/XYTVe/5ibzWg6rvGHyvSm6C3D7Q2sg/NPCLmCtYGGvQA==
+reakit-system@^0.15.1:
+  version "0.15.1"
+  resolved "https://registry.yarnpkg.com/reakit-system/-/reakit-system-0.15.1.tgz#bf5cc7a03f60a817373bc9cbb4a689c1f4100547"
+  integrity sha512-PkqfAyEohtcEu/gUvKriCv42NywDtUgvocEN3147BI45dOFAB89nrT7wRIbIcKJiUT598F+JlPXAZZVLWhc1Kg==
   dependencies:
-    reakit-utils "^0.13.1"
+    reakit-utils "^0.15.1"
 
-reakit-utils@^0.13.0, reakit-utils@^0.13.1:
-  version "0.13.1"
-  resolved "https://registry.yarnpkg.com/reakit-utils/-/reakit-utils-0.13.1.tgz#060b8b2a55eea1170c6d8ff37cd98c10c63ee55c"
-  integrity sha512-NBKgsot3tU91gZgK5MTInI/PR0T3kIsTmbU5MbGggSOcwU2dG/kbE8IrM2lC6ayCSL2W2QWkijT6kewdrIX7Gw==
+reakit-utils@^0.15.1:
+  version "0.15.1"
+  resolved "https://registry.yarnpkg.com/reakit-utils/-/reakit-utils-0.15.1.tgz#797f0a43f6a1dbc22d161224d5d2272e287dbfe3"
+  integrity sha512-6cZgKGvOkAMQgkwU9jdYbHfkuIN1Pr+vwcB19plLvcTfVN0Or10JhIuj9X+JaPZyI7ydqTDFaKNdUcDP69o/+Q==
 
-reakit-utils@^0.14.4:
-  version "0.14.4"
-  resolved "https://registry.yarnpkg.com/reakit-utils/-/reakit-utils-0.14.4.tgz#1ecf035faf58960ba48eac2963f70269596effcf"
-  integrity sha512-jDEf/NmZVJ6fs10G16ifD+RFhQikSLN7VfjRHu0CPoUj4g6lFXd5PPcRXCY81qiqc9FVHjr2d2fmsw1hs6xUxA==
-
-reakit-utils@^0.15.0:
-  version "0.15.0"
-  resolved "https://registry.yarnpkg.com/reakit-utils/-/reakit-utils-0.15.0.tgz#41a53e4b768002d282aee76994737f2532be5afc"
-  integrity sha512-c9HWaT9XU8KQWj+dhUG01WD+D4EK5bQHq+wVwRUuTXau0e49i4udNxo/t/4M3lXeOS+WfgJ8aC00/0imgzPLTw==
-
-reakit-warning@0.4.1, reakit-warning@^0.4.0:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/reakit-warning/-/reakit-warning-0.4.1.tgz#a715302812c5fc7f89f35772d650423f09029b00"
-  integrity sha512-AgnRN6cf8DYBF/mK2JEMFVL67Sbon8fDbFy1kfm0EDibtGsMOQtsFYfozZL7TwmJ4yg68VMhg8tmPHchVQRrlg==
+reakit-warning@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/reakit-warning/-/reakit-warning-0.6.1.tgz#dba33bb8866aebe30e67ac433ead707d16d38a36"
+  integrity sha512-poFUV0EyxB+CcV9uTNBAFmcgsnR2DzAbOTkld4Ul+QOKSeEHZB3b3+MoZQgcYHmbvG19Na1uWaM7ES+/Eyr8tQ==
   dependencies:
-    reakit-utils "^0.13.1"
+    reakit-utils "^0.15.1"
 
-reakit-warning@^0.5.5:
-  version "0.5.5"
-  resolved "https://registry.yarnpkg.com/reakit-warning/-/reakit-warning-0.5.5.tgz#551afcfd9b0c3dc92eab21fcca001fc2ebbc8465"
-  integrity sha512-OuP1r7rlSSJZsoLuc0CPA2ACPKnWO8HDbFktiiidbT67UjuX6udYV1AUsIgMJ8ado9K5gZGjPj7IB/GDYo9Yjg==
+reakit@^1.3.4:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/reakit/-/reakit-1.3.5.tgz#4e35850f4998922541cf9de305549f41931f3272"
+  integrity sha512-Luv1RPBFlWhRG32Ysjd86KC+vLoz5da3X0O8rqClaNEv259nWmnw5fG6BIUSYJwTG6PPxTidPlS+9bS6nLstfA==
   dependencies:
-    reakit-utils "^0.14.4"
-
-reakit@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/reakit/-/reakit-1.1.0.tgz#c30289907722a1fb1aa6a8c4990dac739c60e9c7"
-  integrity sha512-d/ERtwgBndBPsyPBPUl5jueyfFgsglIfQCnLMKuxM0PaWiIZ6Ys3XsYaNy/AaG8k46Ee5cQPMdRrR30nVcSToQ==
-  dependencies:
-    "@popperjs/core" "^2.4.2"
-    body-scroll-lock "^3.0.2"
-    reakit-system "^0.13.0"
-    reakit-utils "^0.13.0"
-    reakit-warning "^0.4.0"
+    "@popperjs/core" "^2.5.4"
+    body-scroll-lock "^3.1.5"
+    reakit-system "^0.15.1"
+    reakit-utils "^0.15.1"
+    reakit-warning "^0.6.1"
 
 realpath-native@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
While working on https://github.com/WordPress/gutenberg/pull/28280, I discovered that Gutenberg uses 2 different versions of Reakit library. This PR tries to resolve that issue. I also removed `reakit-warning` dependency in favor of `@wordpress/warning` that is nearly identical and authored by the same mastermind @diegohaz 😄 


<img width="1278" alt="Screen Shot 2021-01-21 at 13 28 08" src="https://user-images.githubusercontent.com/699132/105351197-85cac500-5bec-11eb-8fdd-b933f682da87.png">

I don't know why it was pinned to v1.1.0. Let's make sure we can use the latest version.