### PR TITLE
SelectDropdown: Fix some a11y voiceover issues

### DIFF
--- a/packages/components/src/Alert/__tests__/__snapshots__/Alert.test.js.snap
+++ b/packages/components/src/Alert/__tests__/__snapshots__/Alert.test.js.snap
@@ -216,6 +216,16 @@ exports[`props should render as dismissable 1`] = `
 }
 
 .emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -310,6 +320,18 @@ exports[`props should render as dismissable 1`] = `
   padding: calc(4px * 0);
   padding: calc(var(--wp-g2-grid-base) * 0);
   color: currentColor;
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6>*+*:not(marquee) {
@@ -583,7 +605,6 @@ exports[`props should render as dismissable 1`] = `
           data-g2-component="CloseButton"
           data-icon="true"
           title="Dismiss"
-          type="button"
         >
           <span
             class="components-flex-item wp-components-flex-item emotion-7"
@@ -1023,6 +1044,16 @@ exports[`props should render with status 1`] = `
 }
 
 .emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1117,6 +1148,18 @@ exports[`props should render with status 1`] = `
   padding: calc(4px * 0);
   padding: calc(var(--wp-g2-grid-base) * 0);
   color: currentColor;
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7>*+*:not(marquee) {
@@ -1671,7 +1714,6 @@ exports[`props should render with status 1`] = `
             data-g2-component="CloseButton"
             data-icon="true"
             title="Dismiss"
-            type="button"
           >
             <span
               class="components-flex-item wp-components-flex-item emotion-8"
@@ -1750,7 +1792,6 @@ exports[`props should render with status 1`] = `
             data-g2-component="CloseButton"
             data-icon="true"
             title="Dismiss"
-            type="button"
           >
             <span
               class="components-flex-item wp-components-flex-item emotion-8"
@@ -1829,7 +1870,6 @@ exports[`props should render with status 1`] = `
             data-g2-component="CloseButton"
             data-icon="true"
             title="Dismiss"
-            type="button"
           >
             <span
               class="components-flex-item wp-components-flex-item emotion-8"
@@ -1908,7 +1948,6 @@ exports[`props should render with status 1`] = `
             data-g2-component="CloseButton"
             data-icon="true"
             title="Dismiss"
-            type="button"
           >
             <span
               class="components-flex-item wp-components-flex-item emotion-8"
@@ -1987,7 +2026,6 @@ exports[`props should render with status 1`] = `
             data-g2-component="CloseButton"
             data-icon="true"
             title="Dismiss"
-            type="button"
           >
             <span
               class="components-flex-item wp-components-flex-item emotion-8"

--- a/packages/components/src/BaseButton/BaseButton.js
+++ b/packages/components/src/BaseButton/BaseButton.js
@@ -2,13 +2,13 @@ import { chevronDown } from '@wordpress/icons';
 import { contextConnect } from '@wp-g2/context';
 import { cx, ui } from '@wp-g2/styles';
 import React from 'react';
-import { Button as ReakitButton } from 'reakit';
 import { Radio as ReakitRadio } from 'reakit';
 
 import { useButtonGroupContext } from '../ButtonGroup';
 import { Elevation } from '../Elevation';
 import { FlexItem } from '../Flex';
 import { Icon } from '../Icon';
+import { View } from '../View';
 import * as styles from './BaseButton.styles';
 import LoadingOverlay from './BaseButtonLoadingOverlay';
 import { useBaseButton } from './useBaseButton';
@@ -42,7 +42,7 @@ function BaseButton(props, forwardedRef) {
 	const { buttonGroup } = useButtonGroupContext();
 	const buttonGroupState = buttonGroup || {};
 
-	const BaseComponent = buttonGroup ? ReakitRadio : ReakitButton;
+	const BaseComponent = buttonGroup ? ReakitRadio : View;
 	const as = asProp || (href ? 'a' : 'button');
 
 	return (

--- a/packages/components/src/BaseButton/__tests__/__snapshots__/BaseButton.test.js.snap
+++ b/packages/components/src/BaseButton/__tests__/__snapshots__/BaseButton.test.js.snap
@@ -2,6 +2,16 @@
 
 exports[`props should render correctly 1`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -72,6 +82,18 @@ exports[`props should render correctly 1`] = `
   user-select: none;
   width: auto;
   text-align: center;
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
@@ -207,7 +229,6 @@ exports[`props should render correctly 1`] = `
   data-g2-c16t="true"
   data-g2-component="BaseButton"
   data-icon="false"
-  type="button"
 >
   <span
     class="components-flex-item wp-components-flex-item emotion-1"

--- a/packages/components/src/Button/__tests__/__snapshots__/Button.test.js.snap
+++ b/packages/components/src/Button/__tests__/__snapshots__/Button.test.js.snap
@@ -2,6 +2,16 @@
 
 exports[`props should render (Flex) gap 1`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -85,6 +95,18 @@ exports[`props should render (Flex) gap 1`] = `
   border-color: var(--wp-g2-button-secondary-border-color);
   color: #007cba;
   color: var(--wp-g2-button-secondary-text-color);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
@@ -273,7 +295,6 @@ exports[`props should render (Flex) gap 1`] = `
   data-g2-c16t="true"
   data-g2-component="Button"
   data-icon="false"
-  type="button"
 >
   <span
     class="components-flex-item wp-components-flex-item emotion-1"
@@ -292,6 +313,16 @@ exports[`props should render (Flex) gap 1`] = `
 
 exports[`props should render as link (href) 1`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -375,6 +406,18 @@ exports[`props should render as link (href) 1`] = `
   border-color: var(--wp-g2-button-secondary-border-color);
   color: #007cba;
   color: var(--wp-g2-button-secondary-text-color);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
@@ -582,6 +625,16 @@ exports[`props should render as link (href) 1`] = `
 
 exports[`props should render correctly 1`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -665,6 +718,18 @@ exports[`props should render correctly 1`] = `
   border-color: var(--wp-g2-button-secondary-border-color);
   color: #007cba;
   color: var(--wp-g2-button-secondary-text-color);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
@@ -853,7 +918,6 @@ exports[`props should render correctly 1`] = `
   data-g2-c16t="true"
   data-g2-component="Button"
   data-icon="false"
-  type="button"
 >
   <span
     class="components-flex-item wp-components-flex-item emotion-1"
@@ -872,6 +936,16 @@ exports[`props should render correctly 1`] = `
 
 exports[`props should render disabled 1`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -955,6 +1029,18 @@ exports[`props should render disabled 1`] = `
   border-color: var(--wp-g2-button-secondary-border-color);
   color: #007cba;
   color: var(--wp-g2-button-secondary-text-color);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
@@ -1136,7 +1222,6 @@ exports[`props should render disabled 1`] = `
 
 <button
   aria-busy="false"
-  aria-disabled="true"
   class="components-flex wp-components-flex components-base-button wp-components-base-button components-button wp-components-button emotion-0"
   data-active="false"
   data-destructive="false"
@@ -1145,8 +1230,6 @@ exports[`props should render disabled 1`] = `
   data-g2-component="Button"
   data-icon="false"
   disabled=""
-  style="pointer-events: none;"
-  type="button"
 >
   <span
     class="components-flex-item wp-components-flex-item emotion-1"
@@ -1165,6 +1248,16 @@ exports[`props should render disabled 1`] = `
 
 exports[`props should render elevation 1`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1248,6 +1341,18 @@ exports[`props should render elevation 1`] = `
   border-color: var(--wp-g2-button-secondary-border-color);
   color: #007cba;
   color: var(--wp-g2-button-secondary-text-color);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
@@ -1436,7 +1541,6 @@ exports[`props should render elevation 1`] = `
   data-g2-c16t="true"
   data-g2-component="Button"
   data-icon="false"
-  type="button"
 >
   <span
     class="components-flex-item wp-components-flex-item emotion-1"
@@ -1455,6 +1559,16 @@ exports[`props should render elevation 1`] = `
 
 exports[`props should render hasCaret 1`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1538,6 +1652,18 @@ exports[`props should render hasCaret 1`] = `
   border-color: var(--wp-g2-button-secondary-border-color);
   color: #007cba;
   color: var(--wp-g2-button-secondary-text-color);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
@@ -1799,7 +1925,6 @@ exports[`props should render hasCaret 1`] = `
   data-g2-c16t="true"
   data-g2-component="Button"
   data-icon="false"
-  type="button"
 >
   <span
     class="components-flex-item wp-components-flex-item emotion-1"
@@ -1844,6 +1969,16 @@ exports[`props should render hasCaret 1`] = `
 
 exports[`props should render icon 1`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1927,6 +2062,18 @@ exports[`props should render icon 1`] = `
   border-color: var(--wp-g2-button-secondary-border-color);
   color: #007cba;
   color: var(--wp-g2-button-secondary-text-color);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
@@ -2193,7 +2340,6 @@ exports[`props should render icon 1`] = `
   data-g2-c16t="true"
   data-g2-component="Button"
   data-icon="true"
-  type="button"
 >
   <span
     class="components-flex-item wp-components-flex-item emotion-1"
@@ -2225,6 +2371,16 @@ exports[`props should render icon 1`] = `
 
 exports[`props should render isControl 1`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2319,6 +2475,18 @@ exports[`props should render isControl 1`] = `
   font-family: var(--wp-g2-font-family);
   font-size: 13px;
   font-size: var(--wp-g2-font-size);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
@@ -2521,7 +2689,6 @@ exports[`props should render isControl 1`] = `
   data-g2-c16t="true"
   data-g2-component="Button"
   data-icon="false"
-  type="button"
 >
   <span
     class="components-flex-item wp-components-flex-item emotion-1"
@@ -2540,6 +2707,16 @@ exports[`props should render isControl 1`] = `
 
 exports[`props should render isDestructive 1`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2625,6 +2802,18 @@ exports[`props should render isDestructive 1`] = `
   border-color: var(--wp-g2-button-secondary-border-color);
   color: #007cba;
   color: var(--wp-g2-button-secondary-text-color);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
@@ -2813,7 +3002,6 @@ exports[`props should render isDestructive 1`] = `
   data-g2-c16t="true"
   data-g2-component="Button"
   data-icon="false"
-  type="button"
 >
   <span
     class="components-flex-item wp-components-flex-item emotion-1"
@@ -2832,6 +3020,16 @@ exports[`props should render isDestructive 1`] = `
 
 exports[`props should render isLoading 1`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2915,6 +3113,18 @@ exports[`props should render isLoading 1`] = `
   border-color: var(--wp-g2-button-secondary-border-color);
   color: #007cba;
   color: var(--wp-g2-button-secondary-text-color);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
@@ -3372,7 +3582,6 @@ exports[`props should render isLoading 1`] = `
 
 <button
   aria-busy="true"
-  aria-disabled="true"
   class="components-flex wp-components-flex components-base-button wp-components-base-button components-button wp-components-button emotion-0"
   data-active="false"
   data-destructive="false"
@@ -3381,8 +3590,6 @@ exports[`props should render isLoading 1`] = `
   data-g2-component="Button"
   data-icon="false"
   disabled=""
-  style="pointer-events: none;"
-  type="button"
 >
   <div
     aria-hidden="true"
@@ -3463,6 +3670,16 @@ exports[`props should render isLoading 1`] = `
 
 exports[`props should render isNarrow 1`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3550,6 +3767,18 @@ exports[`props should render isNarrow 1`] = `
   border-color: var(--wp-g2-button-secondary-border-color);
   color: #007cba;
   color: var(--wp-g2-button-secondary-text-color);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
@@ -3738,7 +3967,6 @@ exports[`props should render isNarrow 1`] = `
   data-g2-c16t="true"
   data-g2-component="Button"
   data-icon="false"
-  type="button"
 >
   <span
     class="components-flex-item wp-components-flex-item emotion-1"
@@ -3757,6 +3985,16 @@ exports[`props should render isNarrow 1`] = `
 
 exports[`props should render isRounded 1`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3843,6 +4081,18 @@ exports[`props should render isRounded 1`] = `
   color: var(--wp-g2-button-secondary-text-color);
 }
 
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
+}
+
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
   margin-left: calc(4px * 2);
   margin-left: calc(var(--wp-g2-grid-base) * 2);
@@ -4029,7 +4279,6 @@ exports[`props should render isRounded 1`] = `
   data-g2-c16t="true"
   data-g2-component="Button"
   data-icon="false"
-  type="button"
 >
   <span
     class="components-flex-item wp-components-flex-item emotion-1"
@@ -4048,6 +4297,16 @@ exports[`props should render isRounded 1`] = `
 
 exports[`props should render isSubtle 1`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -4135,6 +4394,18 @@ exports[`props should render isSubtle 1`] = `
   border-color: var(--wp-g2-control-border-color-subtle);
   color: #1e1e1e;
   color: var(--wp-g2-color-text);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
@@ -4337,7 +4608,6 @@ exports[`props should render isSubtle 1`] = `
   data-g2-c16t="true"
   data-g2-component="Button"
   data-icon="false"
-  type="button"
 >
   <span
     class="components-flex-item wp-components-flex-item emotion-1"
@@ -4356,6 +4626,16 @@ exports[`props should render isSubtle 1`] = `
 
 exports[`props should render prefix 1`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -4439,6 +4719,18 @@ exports[`props should render prefix 1`] = `
   border-color: var(--wp-g2-button-secondary-border-color);
   color: #007cba;
   color: var(--wp-g2-button-secondary-text-color);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
@@ -4667,7 +4959,6 @@ exports[`props should render prefix 1`] = `
   data-g2-c16t="true"
   data-g2-component="Button"
   data-icon="false"
-  type="button"
 >
   <span
     class="components-flex-item wp-components-flex-item emotion-1"
@@ -4695,6 +4986,16 @@ exports[`props should render prefix 1`] = `
 
 exports[`props should render size 1`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -4784,6 +5085,18 @@ exports[`props should render size 1`] = `
   padding-right: var(--wp-g2-control-padding-x);
   min-height: calc(30px * 0.8);
   min-height: var(--wp-g2-control-height-small);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
@@ -4977,7 +5290,6 @@ exports[`props should render size 1`] = `
   data-g2-c16t="true"
   data-g2-component="Button"
   data-icon="false"
-  type="button"
 >
   <span
     class="components-flex-item wp-components-flex-item emotion-1"
@@ -4996,6 +5308,16 @@ exports[`props should render size 1`] = `
 
 exports[`props should render suffix 1`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5079,6 +5401,18 @@ exports[`props should render suffix 1`] = `
   border-color: var(--wp-g2-button-secondary-border-color);
   color: #007cba;
   color: var(--wp-g2-button-secondary-text-color);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
@@ -5307,7 +5641,6 @@ exports[`props should render suffix 1`] = `
   data-g2-c16t="true"
   data-g2-component="Button"
   data-icon="false"
-  type="button"
 >
   <span
     class="components-flex-item wp-components-flex-item emotion-1"
@@ -5335,6 +5668,16 @@ exports[`props should render suffix 1`] = `
 
 exports[`props should render variant 1`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -5418,6 +5761,18 @@ exports[`props should render variant 1`] = `
   border-color: var(--wp-g2-button-primary-border-color);
   color: #ffffff;
   color: var(--wp-g2-button-primary-text-color);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
@@ -5610,7 +5965,6 @@ exports[`props should render variant 1`] = `
   data-g2-c16t="true"
   data-g2-component="Button"
   data-icon="false"
-  type="button"
 >
   <span
     class="components-flex-item wp-components-flex-item emotion-1"

--- a/packages/components/src/Card/__tests__/__snapshots__/Card.test.js.snap
+++ b/packages/components/src/Card/__tests__/__snapshots__/Card.test.js.snap
@@ -259,6 +259,16 @@ exports[`props should render CardInnerBody 1`] = `
 }
 
 .emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -342,6 +352,18 @@ exports[`props should render CardInnerBody 1`] = `
   border-color: var(--wp-g2-button-primary-border-color);
   color: #ffffff;
   color: var(--wp-g2-button-primary-text-color);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5>*+*:not(marquee) {
@@ -651,7 +673,6 @@ exports[`props should render CardInnerBody 1`] = `
         data-g2-c16t="true"
         data-g2-component="Button"
         data-icon="false"
-        type="button"
       >
         <span
           class="components-flex-item wp-components-flex-item emotion-6"
@@ -987,6 +1008,16 @@ exports[`props should render correctly 1`] = `
 }
 
 .emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1070,6 +1101,18 @@ exports[`props should render correctly 1`] = `
   border-color: var(--wp-g2-button-primary-border-color);
   color: #ffffff;
   color: var(--wp-g2-button-primary-text-color);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5>*+*:not(marquee) {
@@ -1379,7 +1422,6 @@ exports[`props should render correctly 1`] = `
         data-g2-c16t="true"
         data-g2-component="Button"
         data-icon="false"
-        type="button"
       >
         <span
           class="components-flex-item wp-components-flex-item emotion-6"

--- a/packages/components/src/ClipboardButton/__tests__/__snapshots__/ClipboardButton.test.js.snap
+++ b/packages/components/src/ClipboardButton/__tests__/__snapshots__/ClipboardButton.test.js.snap
@@ -2,6 +2,16 @@
 
 exports[`props should render correctly 1`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -85,6 +95,18 @@ exports[`props should render correctly 1`] = `
   border-color: var(--wp-g2-button-secondary-border-color);
   color: #007cba;
   color: var(--wp-g2-button-secondary-text-color);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
@@ -273,7 +295,6 @@ exports[`props should render correctly 1`] = `
   data-g2-c16t="true"
   data-g2-component="ClipboardButton"
   data-icon="false"
-  type="button"
 >
   <span
     class="components-flex-item wp-components-flex-item emotion-1"

--- a/packages/components/src/CloseButton/__tests__/__snapshots__/CloseButton.test.js.snap
+++ b/packages/components/src/CloseButton/__tests__/__snapshots__/CloseButton.test.js.snap
@@ -2,6 +2,16 @@
 
 exports[`props should render correctly 1`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -95,6 +105,18 @@ exports[`props should render correctly 1`] = `
   color: var(--wp-g2-color-text);
   padding: calc(4px * 0);
   padding: calc(var(--wp-g2-grid-base) * 0);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
@@ -331,7 +353,6 @@ exports[`props should render correctly 1`] = `
   data-g2-c16t="true"
   data-g2-component="CloseButton"
   data-icon="true"
-  type="button"
 >
   <span
     class="components-flex-item wp-components-flex-item emotion-1"
@@ -369,6 +390,16 @@ exports[`props should render correctly 1`] = `
 
 exports[`props should render size 1`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -464,6 +495,18 @@ exports[`props should render size 1`] = `
   color: var(--wp-g2-color-text);
   padding: calc(4px * 0);
   padding: calc(var(--wp-g2-grid-base) * 0);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
@@ -705,7 +748,6 @@ exports[`props should render size 1`] = `
   data-g2-c16t="true"
   data-g2-component="CloseButton"
   data-icon="true"
-  type="button"
 >
   <span
     class="components-flex-item wp-components-flex-item emotion-1"
@@ -743,6 +785,16 @@ exports[`props should render size 1`] = `
 
 exports[`props should render variant 1`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -836,6 +888,18 @@ exports[`props should render variant 1`] = `
   color: var(--wp-g2-color-text);
   padding: calc(4px * 0);
   padding: calc(var(--wp-g2-grid-base) * 0);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
@@ -1082,7 +1146,6 @@ exports[`props should render variant 1`] = `
   data-g2-c16t="true"
   data-g2-component="CloseButton"
   data-icon="true"
-  type="button"
 >
   <span
     class="components-flex-item wp-components-flex-item emotion-1"

--- a/packages/components/src/Collapsible/__tests__/__snapshots__/Collapsible.test.js.snap
+++ b/packages/components/src/Collapsible/__tests__/__snapshots__/Collapsible.test.js.snap
@@ -27,6 +27,16 @@ exports[`props should render correctly 1`] = `
 }
 
 .emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -110,6 +120,18 @@ exports[`props should render correctly 1`] = `
   border-color: var(--wp-g2-button-secondary-border-color);
   color: #007cba;
   color: var(--wp-g2-button-secondary-text-color);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1>*+*:not(marquee) {
@@ -407,6 +429,16 @@ exports[`props should render visible 1`] = `
 }
 
 .emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -490,6 +522,18 @@ exports[`props should render visible 1`] = `
   border-color: var(--wp-g2-button-secondary-border-color);
   color: #007cba;
   color: var(--wp-g2-button-secondary-text-color);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1>*+*:not(marquee) {

--- a/packages/components/src/ColorControl/__tests__/__snapshots__/ColorControl.test.js.snap
+++ b/packages/components/src/ColorControl/__tests__/__snapshots__/ColorControl.test.js.snap
@@ -2,6 +2,16 @@
 
 exports[`props should render correctly 1`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -111,6 +121,18 @@ exports[`props should render correctly 1`] = `
   padding-left: calc(var(--wp-g2-grid-base) * 1);
   padding-right: calc(4px * 1);
   padding-right: calc(var(--wp-g2-grid-base) * 1);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
@@ -540,7 +562,6 @@ exports[`props should render correctly 1`] = `
   data-g2-c16t="true"
   data-g2-component="ColorControl"
   data-icon="false"
-  type="button"
 >
   <span
     class="components-flex-item wp-components-flex-item emotion-1"

--- a/packages/components/src/ControlGroup/__tests__/__snapshots__/ControlGroup.test.js.snap
+++ b/packages/components/src/ControlGroup/__tests__/__snapshots__/ControlGroup.test.js.snap
@@ -60,6 +60,16 @@ exports[`props should render correctly 1`] = `
 }
 
 .emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -145,6 +155,18 @@ exports[`props should render correctly 1`] = `
   border-color: var(--wp-g2-button-secondary-border-color);
   color: #007cba;
   color: var(--wp-g2-button-secondary-text-color);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1>*+*:not(marquee) {
@@ -325,6 +347,16 @@ exports[`props should render correctly 1`] = `
 }
 
 .emotion-4.emotion-4.emotion-4.emotion-4.emotion-4.emotion-4.emotion-4 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -410,6 +442,18 @@ exports[`props should render correctly 1`] = `
   border-color: var(--wp-g2-button-secondary-border-color);
   color: #007cba;
   color: var(--wp-g2-button-secondary-text-color);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-4.emotion-4.emotion-4.emotion-4.emotion-4.emotion-4.emotion-4 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-4.emotion-4.emotion-4.emotion-4.emotion-4.emotion-4.emotion-4 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-4.emotion-4.emotion-4.emotion-4.emotion-4.emotion-4.emotion-4>*+*:not(marquee) {
@@ -522,7 +566,6 @@ exports[`props should render correctly 1`] = `
     data-g2-c16t="true"
     data-g2-component="Button"
     data-icon="false"
-    type="button"
   >
     <span
       class="components-flex-item wp-components-flex-item emotion-2"
@@ -546,7 +589,6 @@ exports[`props should render correctly 1`] = `
     data-g2-c16t="true"
     data-g2-component="Button"
     data-icon="false"
-    type="button"
   >
     <span
       class="components-flex-item wp-components-flex-item emotion-2"
@@ -1121,6 +1163,16 @@ exports[`props should render mixed control types 1`] = `
 }
 
 .emotion-8.emotion-8.emotion-8.emotion-8.emotion-8.emotion-8.emotion-8 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1206,6 +1258,18 @@ exports[`props should render mixed control types 1`] = `
   border-color: var(--wp-g2-button-secondary-border-color);
   color: #007cba;
   color: var(--wp-g2-button-secondary-text-color);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-8.emotion-8.emotion-8.emotion-8.emotion-8.emotion-8.emotion-8 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-8.emotion-8.emotion-8.emotion-8.emotion-8.emotion-8.emotion-8 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-8.emotion-8.emotion-8.emotion-8.emotion-8.emotion-8.emotion-8>*+*:not(marquee) {
@@ -1459,7 +1523,6 @@ exports[`props should render mixed control types 1`] = `
     data-g2-c16t="true"
     data-g2-component="Button"
     data-icon="false"
-    type="button"
   >
     <span
       class="components-flex-item wp-components-flex-item emotion-9"

--- a/packages/components/src/Popover/__tests__/__snapshots__/Popover.test.js.snap
+++ b/packages/components/src/Popover/__tests__/__snapshots__/Popover.test.js.snap
@@ -2,6 +2,16 @@
 
 exports[`props should render correctly 1`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -85,6 +95,18 @@ exports[`props should render correctly 1`] = `
   border-color: var(--wp-g2-button-secondary-border-color);
   color: #007cba;
   color: var(--wp-g2-button-secondary-text-color);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
@@ -295,6 +317,16 @@ exports[`props should render correctly 1`] = `
 
 exports[`props should render gutter 1`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -378,6 +410,18 @@ exports[`props should render gutter 1`] = `
   border-color: var(--wp-g2-button-secondary-border-color);
   color: #007cba;
   color: var(--wp-g2-button-secondary-text-color);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
@@ -588,6 +632,16 @@ exports[`props should render gutter 1`] = `
 
 exports[`props should render label 1`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -671,6 +725,18 @@ exports[`props should render label 1`] = `
   border-color: var(--wp-g2-button-secondary-border-color);
   color: #007cba;
   color: var(--wp-g2-button-secondary-text-color);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
@@ -881,6 +947,16 @@ exports[`props should render label 1`] = `
 
 exports[`props should render maxWidth 1`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -964,6 +1040,18 @@ exports[`props should render maxWidth 1`] = `
   border-color: var(--wp-g2-button-secondary-border-color);
   color: #007cba;
   color: var(--wp-g2-button-secondary-text-color);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
@@ -1174,6 +1262,16 @@ exports[`props should render maxWidth 1`] = `
 
 exports[`props should render placement 1`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1257,6 +1355,18 @@ exports[`props should render placement 1`] = `
   border-color: var(--wp-g2-button-secondary-border-color);
   color: #007cba;
   color: var(--wp-g2-button-secondary-text-color);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
@@ -1467,6 +1577,16 @@ exports[`props should render placement 1`] = `
 
 exports[`props should render visible 1`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1550,6 +1670,18 @@ exports[`props should render visible 1`] = `
   border-color: var(--wp-g2-button-secondary-border-color);
   color: #007cba;
   color: var(--wp-g2-button-secondary-text-color);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
@@ -1760,6 +1892,16 @@ exports[`props should render visible 1`] = `
 
 exports[`props should render without animation 1`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1843,6 +1985,18 @@ exports[`props should render without animation 1`] = `
   border-color: var(--wp-g2-button-secondary-border-color);
   color: #007cba;
   color: var(--wp-g2-button-secondary-text-color);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
@@ -2053,6 +2207,16 @@ exports[`props should render without animation 1`] = `
 
 exports[`props should render without content 1`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2136,6 +2300,18 @@ exports[`props should render without content 1`] = `
   border-color: var(--wp-g2-button-secondary-border-color);
   color: #007cba;
   color: var(--wp-g2-button-secondary-text-color);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
@@ -2346,6 +2522,16 @@ exports[`props should render without content 1`] = `
 
 exports[`props should render without modal 1`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2429,6 +2615,18 @@ exports[`props should render without modal 1`] = `
   border-color: var(--wp-g2-button-secondary-border-color);
   color: #007cba;
   color: var(--wp-g2-button-secondary-text-color);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {

--- a/packages/components/src/SearchInput/__tests__/__snapshots__/SearchInput.test.js.snap
+++ b/packages/components/src/SearchInput/__tests__/__snapshots__/SearchInput.test.js.snap
@@ -331,6 +331,16 @@ exports[`props should render correctly 1`] = `
 }
 
 .emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -427,6 +437,18 @@ exports[`props should render correctly 1`] = `
   min-height: var(--wp-g2-control-height-xx-small);
   padding: calc(4px * 0);
   padding: calc(var(--wp-g2-grid-base) * 0);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6>*+*:not(marquee) {
@@ -711,7 +733,6 @@ exports[`props should render correctly 1`] = `
       data-g2-component="Button"
       data-icon="true"
       tabindex="-1"
-      type="button"
     >
       <span
         class="components-flex-item wp-components-flex-item emotion-7"
@@ -1222,6 +1243,16 @@ exports[`props should render isLoading 1`] = `
 }
 
 .emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1318,6 +1349,18 @@ exports[`props should render isLoading 1`] = `
   min-height: var(--wp-g2-control-height-xx-small);
   padding: calc(4px * 0);
   padding: calc(var(--wp-g2-grid-base) * 0);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7>*+*:not(marquee) {
@@ -1630,7 +1673,6 @@ exports[`props should render isLoading 1`] = `
       data-g2-component="Button"
       data-icon="true"
       tabindex="-1"
-      type="button"
     >
       <span
         class="components-flex-item wp-components-flex-item emotion-8"
@@ -1999,6 +2041,16 @@ exports[`props should render placeholder 1`] = `
 }
 
 .emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2095,6 +2147,18 @@ exports[`props should render placeholder 1`] = `
   min-height: var(--wp-g2-control-height-xx-small);
   padding: calc(4px * 0);
   padding: calc(var(--wp-g2-grid-base) * 0);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6>*+*:not(marquee) {
@@ -2379,7 +2443,6 @@ exports[`props should render placeholder 1`] = `
       data-g2-component="Button"
       data-icon="true"
       tabindex="-1"
-      type="button"
     >
       <span
         class="components-flex-item wp-components-flex-item emotion-7"
@@ -2748,6 +2811,16 @@ exports[`props should render prefix 1`] = `
 }
 
 .emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2844,6 +2917,18 @@ exports[`props should render prefix 1`] = `
   min-height: var(--wp-g2-control-height-xx-small);
   padding: calc(4px * 0);
   padding: calc(var(--wp-g2-grid-base) * 0);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6>*+*:not(marquee) {
@@ -3131,7 +3216,6 @@ exports[`props should render prefix 1`] = `
       data-g2-component="Button"
       data-icon="true"
       tabindex="-1"
-      type="button"
     >
       <span
         class="components-flex-item wp-components-flex-item emotion-7"
@@ -3500,6 +3584,16 @@ exports[`props should render suffix 1`] = `
 }
 
 .emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3596,6 +3690,18 @@ exports[`props should render suffix 1`] = `
   min-height: var(--wp-g2-control-height-xx-small);
   padding: calc(4px * 0);
   padding: calc(var(--wp-g2-grid-base) * 0);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6>*+*:not(marquee) {
@@ -3883,7 +3989,6 @@ exports[`props should render suffix 1`] = `
       data-g2-component="Button"
       data-icon="true"
       tabindex="-1"
-      type="button"
     >
       <span
         class="components-flex-item wp-components-flex-item emotion-7"
@@ -4252,6 +4357,16 @@ exports[`props should render value 1`] = `
 }
 
 .emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -4348,6 +4463,18 @@ exports[`props should render value 1`] = `
   min-height: var(--wp-g2-control-height-xx-small);
   padding: calc(4px * 0);
   padding: calc(var(--wp-g2-grid-base) * 0);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6>*+*:not(marquee) {
@@ -4632,7 +4759,6 @@ exports[`props should render value 1`] = `
       data-g2-component="Button"
       data-icon="true"
       tabindex="-1"
-      type="button"
     >
       <span
         class="components-flex-item wp-components-flex-item emotion-7"

--- a/packages/components/src/Stepper/__tests__/__snapshots__/Stepper.test.js.snap
+++ b/packages/components/src/Stepper/__tests__/__snapshots__/Stepper.test.js.snap
@@ -66,6 +66,16 @@ exports[`props should render correctly 1`] = `
 }
 
 .emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -173,6 +183,18 @@ exports[`props should render correctly 1`] = `
   font-size: var(--wp-g2-font-size);
   padding: calc(4px * 0);
   padding: calc(var(--wp-g2-grid-base) * 0);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1>*+*:not(marquee) {
@@ -407,6 +429,16 @@ exports[`props should render correctly 1`] = `
 }
 
 .emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -514,6 +546,18 @@ exports[`props should render correctly 1`] = `
   font-size: var(--wp-g2-font-size);
   padding: calc(4px * 0);
   padding: calc(var(--wp-g2-grid-base) * 0);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5>*+*:not(marquee) {
@@ -640,7 +684,6 @@ exports[`props should render correctly 1`] = `
     data-g2-c16t="true"
     data-g2-component="StepperButton"
     data-icon="true"
-    type="button"
   >
     <span
       class="components-flex-item wp-components-flex-item emotion-2"
@@ -683,7 +726,6 @@ exports[`props should render correctly 1`] = `
     data-g2-c16t="true"
     data-g2-component="StepperButton"
     data-icon="true"
-    type="button"
   >
     <span
       class="components-flex-item wp-components-flex-item emotion-2"
@@ -786,6 +828,16 @@ exports[`props should render size 1`] = `
 }
 
 .emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -899,6 +951,18 @@ exports[`props should render size 1`] = `
   font-size: var(--wp-g2-font-size);
   padding: calc(4px * 0);
   padding: calc(var(--wp-g2-grid-base) * 0);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1>*+*:not(marquee) {
@@ -1138,6 +1202,16 @@ exports[`props should render size 1`] = `
 }
 
 .emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1251,6 +1325,18 @@ exports[`props should render size 1`] = `
   font-size: var(--wp-g2-font-size);
   padding: calc(4px * 0);
   padding: calc(var(--wp-g2-grid-base) * 0);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5>*+*:not(marquee) {
@@ -1382,7 +1468,6 @@ exports[`props should render size 1`] = `
     data-g2-c16t="true"
     data-g2-component="StepperButton"
     data-icon="true"
-    type="button"
   >
     <span
       class="components-flex-item wp-components-flex-item emotion-2"
@@ -1425,7 +1510,6 @@ exports[`props should render size 1`] = `
     data-g2-c16t="true"
     data-g2-component="StepperButton"
     data-icon="true"
-    type="button"
   >
     <span
       class="components-flex-item wp-components-flex-item emotion-2"
@@ -1523,6 +1607,16 @@ exports[`props should render vertically 1`] = `
 }
 
 .emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1632,6 +1726,18 @@ exports[`props should render vertically 1`] = `
   font-size: var(--wp-g2-font-size);
   padding: calc(4px * 0);
   padding: calc(var(--wp-g2-grid-base) * 0);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1>*+*:not(marquee) {
@@ -1871,6 +1977,16 @@ exports[`props should render vertically 1`] = `
 }
 
 .emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1980,6 +2096,18 @@ exports[`props should render vertically 1`] = `
   font-size: var(--wp-g2-font-size);
   padding: calc(4px * 0);
   padding: calc(var(--wp-g2-grid-base) * 0);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5>*+*:not(marquee) {
@@ -2111,7 +2239,6 @@ exports[`props should render vertically 1`] = `
     data-g2-c16t="true"
     data-g2-component="StepperButton"
     data-icon="true"
-    type="button"
   >
     <span
       class="components-flex-item wp-components-flex-item emotion-2"
@@ -2154,7 +2281,6 @@ exports[`props should render vertically 1`] = `
     data-g2-c16t="true"
     data-g2-component="StepperButton"
     data-icon="true"
-    type="button"
   >
     <span
       class="components-flex-item wp-components-flex-item emotion-2"

--- a/packages/components/src/Tag/__tests__/__snapshots__/Tag.test.js.snap
+++ b/packages/components/src/Tag/__tests__/__snapshots__/Tag.test.js.snap
@@ -634,6 +634,16 @@ exports[`props should render removeButtonText 1`] = `
 }
 
 .emotion-3.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -734,6 +744,18 @@ exports[`props should render removeButtonText 1`] = `
   padding: calc(4px * 0);
   padding: calc(var(--wp-g2-grid-base) * 0);
   color: currentColor;
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-3.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-3.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-3.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3>*+*:not(marquee) {
@@ -998,7 +1020,6 @@ exports[`props should render removeButtonText 1`] = `
       data-g2-component="TagRemoveButton"
       data-icon="true"
       title="Remove"
-      type="button"
     >
       <span
         class="components-flex-item wp-components-flex-item emotion-4"

--- a/packages/components/src/TextInput/types.ts
+++ b/packages/components/src/TextInput/types.ts
@@ -51,7 +51,7 @@ export type Props = Omit<BaseFieldProps, 'isClickable' | 'isSubtle'> &
 		/**
 		 * Fires the `onChange` callback after pressing `ENTER` or focusing away.
 		 *
-		 * @default 2.5
+		 * @default false
 		 */
 		isCommitOnBlurOrEnter?: boolean;
 		/**

--- a/packages/components/src/TextInput/useTextInput.js
+++ b/packages/components/src/TextInput/useTextInput.js
@@ -60,7 +60,7 @@ export function useTextInput(props) {
 		gap = 2.5,
 		id: idProp,
 		incrementFromNonNumericValue = false,
-		isCommitOnBlurOrEnter = true,
+		isCommitOnBlurOrEnter = false,
 		isFocused: isFocusedProp,
 		isInline = false,
 		isResizable = false,

--- a/packages/components/src/TextInput/useTextInputState.js
+++ b/packages/components/src/TextInput/useTextInputState.js
@@ -278,7 +278,7 @@ export function useTextInputState(props) {
 		defaultValue,
 		dragAxis = 'y',
 		incrementFromNonNumericValue = false,
-		isCommitOnBlurOrEnter = true,
+		isCommitOnBlurOrEnter = false,
 		isFocused: isFocusedProp = false,
 		onChange: onChangeProp = noop,
 		value: valueProp,

--- a/packages/components/src/Tooltip/__tests__/__snapshots__/Tooltip.test.js.snap
+++ b/packages/components/src/Tooltip/__tests__/__snapshots__/Tooltip.test.js.snap
@@ -2,6 +2,16 @@
 
 exports[`props should render animatedDuration 1`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -85,6 +95,18 @@ exports[`props should render animatedDuration 1`] = `
   border-color: var(--wp-g2-button-secondary-border-color);
   color: #007cba;
   color: var(--wp-g2-button-secondary-text-color);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
@@ -275,7 +297,6 @@ exports[`props should render animatedDuration 1`] = `
   data-g2-component="Button"
   data-icon="false"
   tabindex="0"
-  type="button"
 >
   <span
     class="components-flex-item wp-components-flex-item emotion-1"
@@ -294,6 +315,16 @@ exports[`props should render animatedDuration 1`] = `
 
 exports[`props should render correctly 1`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -377,6 +408,18 @@ exports[`props should render correctly 1`] = `
   border-color: var(--wp-g2-button-secondary-border-color);
   color: #007cba;
   color: var(--wp-g2-button-secondary-text-color);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
@@ -567,7 +610,6 @@ exports[`props should render correctly 1`] = `
   data-g2-component="Button"
   data-icon="false"
   tabindex="0"
-  type="button"
 >
   <span
     class="components-flex-item wp-components-flex-item emotion-1"
@@ -586,6 +628,16 @@ exports[`props should render correctly 1`] = `
 
 exports[`props should render gutter 1`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -669,6 +721,18 @@ exports[`props should render gutter 1`] = `
   border-color: var(--wp-g2-button-secondary-border-color);
   color: #007cba;
   color: var(--wp-g2-button-secondary-text-color);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
@@ -859,7 +923,6 @@ exports[`props should render gutter 1`] = `
   data-g2-component="Button"
   data-icon="false"
   tabindex="0"
-  type="button"
 >
   <span
     class="components-flex-item wp-components-flex-item emotion-1"
@@ -878,6 +941,16 @@ exports[`props should render gutter 1`] = `
 
 exports[`props should render placement 1`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -961,6 +1034,18 @@ exports[`props should render placement 1`] = `
   border-color: var(--wp-g2-button-secondary-border-color);
   color: #007cba;
   color: var(--wp-g2-button-secondary-text-color);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
@@ -1151,7 +1236,6 @@ exports[`props should render placement 1`] = `
   data-g2-component="Button"
   data-icon="false"
   tabindex="0"
-  type="button"
 >
   <span
     class="components-flex-item wp-components-flex-item emotion-1"
@@ -1170,6 +1254,16 @@ exports[`props should render placement 1`] = `
 
 exports[`props should render visible 1`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1253,6 +1347,18 @@ exports[`props should render visible 1`] = `
   border-color: var(--wp-g2-button-secondary-border-color);
   color: #007cba;
   color: var(--wp-g2-button-secondary-text-color);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
@@ -1443,7 +1549,6 @@ exports[`props should render visible 1`] = `
   data-g2-component="Button"
   data-icon="false"
   tabindex="0"
-  type="button"
 >
   <span
     class="components-flex-item wp-components-flex-item emotion-1"
@@ -1462,6 +1567,16 @@ exports[`props should render visible 1`] = `
 
 exports[`props should render without animation 1`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1545,6 +1660,18 @@ exports[`props should render without animation 1`] = `
   border-color: var(--wp-g2-button-secondary-border-color);
   color: #007cba;
   color: var(--wp-g2-button-secondary-text-color);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
@@ -1735,7 +1862,6 @@ exports[`props should render without animation 1`] = `
   data-g2-component="Button"
   data-icon="false"
   tabindex="0"
-  type="button"
 >
   <span
     class="components-flex-item wp-components-flex-item emotion-1"
@@ -1756,6 +1882,16 @@ exports[`props should render without children 1`] = `null`;
 
 exports[`props should render without content 1`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1839,6 +1975,18 @@ exports[`props should render without content 1`] = `
   border-color: var(--wp-g2-button-secondary-border-color);
   color: #007cba;
   color: var(--wp-g2-button-secondary-text-color);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
@@ -2029,7 +2177,6 @@ exports[`props should render without content 1`] = `
   data-g2-component="Button"
   data-icon="false"
   tabindex="0"
-  type="button"
 >
   <span
     class="components-flex-item wp-components-flex-item emotion-1"
@@ -2048,6 +2195,16 @@ exports[`props should render without content 1`] = `
 
 exports[`props should render without modal 1`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2131,6 +2288,18 @@ exports[`props should render without modal 1`] = `
   border-color: var(--wp-g2-button-secondary-border-color);
   color: #007cba;
   color: var(--wp-g2-button-secondary-text-color);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
@@ -2321,7 +2490,6 @@ exports[`props should render without modal 1`] = `
   data-g2-component="Button"
   data-icon="false"
   tabindex="0"
-  type="button"
 >
   <span
     class="components-flex-item wp-components-flex-item emotion-1"

--- a/packages/components/src/UnitInput/useUnitInput.js
+++ b/packages/components/src/UnitInput/useUnitInput.js
@@ -26,6 +26,7 @@ export function useUnitInput(props) {
 		arrows = false,
 		allowEmptyValue = false,
 		cssProp,
+		isCommitOnBlurOrEnter = true,
 		fallbackUnit = 'px',
 		incrementFromNonNumericValue = true,
 		onChange = noop,
@@ -46,5 +47,6 @@ export function useUnitInput(props) {
 		...otherProps,
 		...unitState,
 		arrows,
+		isCommitOnBlurOrEnter,
 	};
 }

--- a/packages/components/src/__tests__/__snapshots__/Components.test.js.snap
+++ b/packages/components/src/__tests__/__snapshots__/Components.test.js.snap
@@ -26985,6 +26985,278 @@ exports[`props should render SelectDropdown 1`] = `
   display: block;
 }
 
+.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7 {
+  -webkit-transition: none!important;
+  transition: none!important;
+}
+
+.emotion-8.emotion-8.emotion-8.emotion-8.emotion-8.emotion-8.emotion-8 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
+  outline: none;
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-8.emotion-8.emotion-8.emotion-8.emotion-8.emotion-8.emotion-8 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-8.emotion-8.emotion-8.emotion-8.emotion-8.emotion-8.emotion-8 {
+  -webkit-transition: none!important;
+  transition: none!important;
+}
+
+.emotion-9.emotion-9.emotion-9.emotion-9.emotion-9.emotion-9.emotion-9 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
+  background-color: #ffffff;
+  background-color: var(--wp-g2-surface-color);
+  color: #1e1e1e;
+  color: var(--wp-g2-color-text);
+  position: relative;
+  --wp-g2-surface-background-size: 16px;
+  --wp-g2-surface-background-size-dotted: 15px;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 0 0 1px var(--wp-g2-surface-border-color);
+  outline: none;
+  border-radius: 2px;
+  border-radius: var(--wp-g2-card-border-radius);
+  display: none;
+  width: 100%;
+  min-width: 200px;
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-9.emotion-9.emotion-9.emotion-9.emotion-9.emotion-9.emotion-9 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-9.emotion-9.emotion-9.emotion-9.emotion-9.emotion-9.emotion-9 {
+  -webkit-transition: none!important;
+  transition: none!important;
+}
+
+.emotion-10.emotion-10.emotion-10.emotion-10.emotion-10.emotion-10.emotion-10 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
+  height: 100%;
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-10.emotion-10.emotion-10.emotion-10.emotion-10.emotion-10.emotion-10 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-10.emotion-10.emotion-10.emotion-10.emotion-10.emotion-10.emotion-10 {
+  -webkit-transition: none!important;
+  transition: none!important;
+}
+
+.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
+  height: 100%;
+  overflow-x: hidden;
+  overflow-y: auto;
+  max-height: 50vh;
+  padding: calc(4px * 1);
+  padding: calc(var(--wp-g2-grid-base) * 1);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11 {
+  -webkit-transition: none!important;
+  transition: none!important;
+}
+
+@media only screen and (min-device-width:40em) {
+  .emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11::-webkit-scrollbar {
+    height: 12px;
+    width: 12px;
+  }
+
+  .emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11::-webkit-scrollbar-track {
+    background-color: transparent;
+  }
+
+  .emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11::-webkit-scrollbar-track {
+    background: rgba(0, 0, 0, 0.04);
+    background: var(--wp-g2-color-scrollbar-track);
+    border-radius: 8px;
+  }
+
+  .emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11::-webkit-scrollbar-thumb {
+    background-clip: padding-box;
+    background-color: rgba(0, 0, 0, 0.2);
+    background-color: var(--wp-g2-color-scrollbar-thumb);
+    border: 2px solid rgba(0,0,0,0);
+    border-radius: 7px;
+  }
+
+  .emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11:hover::-webkit-scrollbar-thumb {
+    background-color: rgba(0, 0, 0, 0.5);
+    background-color: var(--wp-g2-color-scrollbar-thumb-hover);
+  }
+}
+
+.emotion-12.emotion-12.emotion-12.emotion-12.emotion-12.emotion-12.emotion-12 {
+  outline: none;
+}
+
+.emotion-13.emotion-13.emotion-13.emotion-13.emotion-13.emotion-13.emotion-13 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
+  background: transparent;
+  display: block;
+  margin: 0!important;
+  pointer-events: none;
+  position: absolute;
+  will-change: box-shadow;
+  border-radius: inherit;
+  bottom: 0;
+  box-shadow: 0 1px 2px 0 rgba(0 ,0,0,0.05);
+  opacity: 1;
+  opacity: var(--wp-g2-elevation-intensity);
+  left: 0;
+  right: 0;
+  top: 0;
+  -webkit-transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
+  -webkit-transition: box-shadow var(--wp-g2-transition-duration) var(--wp-g2-transition-timing-function);
+  transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
+  transition: box-shadow var(--wp-g2-transition-duration) var(--wp-g2-transition-timing-function);
+  border-radius: 2px;
+  border-radius: var(--wp-g2-card-border-radius);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-13.emotion-13.emotion-13.emotion-13.emotion-13.emotion-13.emotion-13 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-13.emotion-13.emotion-13.emotion-13.emotion-13.emotion-13.emotion-13 {
+  -webkit-transition: none!important;
+  transition: none!important;
+}
+
+.emotion-14.emotion-14.emotion-14.emotion-14.emotion-14.emotion-14.emotion-14 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
+  background: transparent;
+  display: block;
+  margin: 0!important;
+  pointer-events: none;
+  position: absolute;
+  will-change: box-shadow;
+  border-radius: inherit;
+  bottom: 0;
+  box-shadow: 0 3px 6px 0 rgba(0 ,0,0,0.15);
+  opacity: 1;
+  opacity: var(--wp-g2-elevation-intensity);
+  left: 0;
+  right: 0;
+  top: 0;
+  -webkit-transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
+  -webkit-transition: box-shadow var(--wp-g2-transition-duration) var(--wp-g2-transition-timing-function);
+  transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
+  transition: box-shadow var(--wp-g2-transition-duration) var(--wp-g2-transition-timing-function);
+  border-radius: 2px;
+  border-radius: var(--wp-g2-card-border-radius);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-14.emotion-14.emotion-14.emotion-14.emotion-14.emotion-14.emotion-14 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-14.emotion-14.emotion-14.emotion-14.emotion-14.emotion-14.emotion-14 {
+  -webkit-transition: none!important;
+  transition: none!important;
+}
+
 <div
   class="components-select-dropdown wp-components-select-dropdown emotion-0"
   data-g2-c16t="true"
@@ -27047,6 +27319,54 @@ exports[`props should render SelectDropdown 1`] = `
           </svg>
         </div>
       </span>
+    </div>
+  </div>
+  <label
+    class="emotion-7"
+    data-g2-component="SelectDropdownLabel"
+    for="downshift-0-toggle-button"
+    id="downshift-0-label"
+  />
+  <div
+    aria-hidden="true"
+    class="emotion-8"
+    data-g2-component="SelectDropdownPopover"
+    style="width: 100%; position: absolute; left: 0px; top: 0px; margin: 0px; max-width: 0;"
+  >
+    <div
+      class="components-surface wp-components-surface components-card wp-components-card components-dropdown-menu-card wp-components-dropdown-menu-card emotion-9"
+      data-g2-c16t="true"
+      data-g2-component="SelectDropdownMenu"
+    >
+      <div
+        class="emotion-10"
+        data-g2-component="CardContent"
+      >
+        <div
+          class="components-scrollable wp-components-scrollable emotion-11"
+          data-g2-c16t="true"
+          data-g2-component="Scrollable"
+        >
+          <div
+            aria-hidden="true"
+            aria-labelledby="downshift-0-label"
+            class="emotion-12"
+            id="downshift-0-menu"
+            role="listbox"
+            tabindex="-1"
+          />
+        </div>
+      </div>
+      <div
+        class="components-elevation wp-components-elevation emotion-13"
+        data-g2-c16t="true"
+        data-g2-component="CardElevation"
+      />
+      <div
+        class="components-elevation wp-components-elevation emotion-14"
+        data-g2-c16t="true"
+        data-g2-component="CardElevation"
+      />
     </div>
   </div>
 </div>
@@ -27430,6 +27750,278 @@ exports[`props should render SelectDropdown with css prop 1`] = `
   display: block;
 }
 
+.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7 {
+  -webkit-transition: none!important;
+  transition: none!important;
+}
+
+.emotion-8.emotion-8.emotion-8.emotion-8.emotion-8.emotion-8.emotion-8 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
+  outline: none;
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-8.emotion-8.emotion-8.emotion-8.emotion-8.emotion-8.emotion-8 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-8.emotion-8.emotion-8.emotion-8.emotion-8.emotion-8.emotion-8 {
+  -webkit-transition: none!important;
+  transition: none!important;
+}
+
+.emotion-9.emotion-9.emotion-9.emotion-9.emotion-9.emotion-9.emotion-9 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
+  background-color: #ffffff;
+  background-color: var(--wp-g2-surface-color);
+  color: #1e1e1e;
+  color: var(--wp-g2-color-text);
+  position: relative;
+  --wp-g2-surface-background-size: 16px;
+  --wp-g2-surface-background-size-dotted: 15px;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 0 0 1px var(--wp-g2-surface-border-color);
+  outline: none;
+  border-radius: 2px;
+  border-radius: var(--wp-g2-card-border-radius);
+  display: none;
+  width: 100%;
+  min-width: 200px;
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-9.emotion-9.emotion-9.emotion-9.emotion-9.emotion-9.emotion-9 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-9.emotion-9.emotion-9.emotion-9.emotion-9.emotion-9.emotion-9 {
+  -webkit-transition: none!important;
+  transition: none!important;
+}
+
+.emotion-10.emotion-10.emotion-10.emotion-10.emotion-10.emotion-10.emotion-10 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
+  height: 100%;
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-10.emotion-10.emotion-10.emotion-10.emotion-10.emotion-10.emotion-10 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-10.emotion-10.emotion-10.emotion-10.emotion-10.emotion-10.emotion-10 {
+  -webkit-transition: none!important;
+  transition: none!important;
+}
+
+.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
+  height: 100%;
+  overflow-x: hidden;
+  overflow-y: auto;
+  max-height: 50vh;
+  padding: calc(4px * 1);
+  padding: calc(var(--wp-g2-grid-base) * 1);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11 {
+  -webkit-transition: none!important;
+  transition: none!important;
+}
+
+@media only screen and (min-device-width:40em) {
+  .emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11::-webkit-scrollbar {
+    height: 12px;
+    width: 12px;
+  }
+
+  .emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11::-webkit-scrollbar-track {
+    background-color: transparent;
+  }
+
+  .emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11::-webkit-scrollbar-track {
+    background: rgba(0, 0, 0, 0.04);
+    background: var(--wp-g2-color-scrollbar-track);
+    border-radius: 8px;
+  }
+
+  .emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11::-webkit-scrollbar-thumb {
+    background-clip: padding-box;
+    background-color: rgba(0, 0, 0, 0.2);
+    background-color: var(--wp-g2-color-scrollbar-thumb);
+    border: 2px solid rgba(0,0,0,0);
+    border-radius: 7px;
+  }
+
+  .emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11:hover::-webkit-scrollbar-thumb {
+    background-color: rgba(0, 0, 0, 0.5);
+    background-color: var(--wp-g2-color-scrollbar-thumb-hover);
+  }
+}
+
+.emotion-12.emotion-12.emotion-12.emotion-12.emotion-12.emotion-12.emotion-12 {
+  outline: none;
+}
+
+.emotion-13.emotion-13.emotion-13.emotion-13.emotion-13.emotion-13.emotion-13 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
+  background: transparent;
+  display: block;
+  margin: 0!important;
+  pointer-events: none;
+  position: absolute;
+  will-change: box-shadow;
+  border-radius: inherit;
+  bottom: 0;
+  box-shadow: 0 1px 2px 0 rgba(0 ,0,0,0.05);
+  opacity: 1;
+  opacity: var(--wp-g2-elevation-intensity);
+  left: 0;
+  right: 0;
+  top: 0;
+  -webkit-transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
+  -webkit-transition: box-shadow var(--wp-g2-transition-duration) var(--wp-g2-transition-timing-function);
+  transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
+  transition: box-shadow var(--wp-g2-transition-duration) var(--wp-g2-transition-timing-function);
+  border-radius: 2px;
+  border-radius: var(--wp-g2-card-border-radius);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-13.emotion-13.emotion-13.emotion-13.emotion-13.emotion-13.emotion-13 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-13.emotion-13.emotion-13.emotion-13.emotion-13.emotion-13.emotion-13 {
+  -webkit-transition: none!important;
+  transition: none!important;
+}
+
+.emotion-14.emotion-14.emotion-14.emotion-14.emotion-14.emotion-14.emotion-14 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
+  background: transparent;
+  display: block;
+  margin: 0!important;
+  pointer-events: none;
+  position: absolute;
+  will-change: box-shadow;
+  border-radius: inherit;
+  bottom: 0;
+  box-shadow: 0 3px 6px 0 rgba(0 ,0,0,0.15);
+  opacity: 1;
+  opacity: var(--wp-g2-elevation-intensity);
+  left: 0;
+  right: 0;
+  top: 0;
+  -webkit-transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
+  -webkit-transition: box-shadow var(--wp-g2-transition-duration) var(--wp-g2-transition-timing-function);
+  transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
+  transition: box-shadow var(--wp-g2-transition-duration) var(--wp-g2-transition-timing-function);
+  border-radius: 2px;
+  border-radius: var(--wp-g2-card-border-radius);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-14.emotion-14.emotion-14.emotion-14.emotion-14.emotion-14.emotion-14 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-14.emotion-14.emotion-14.emotion-14.emotion-14.emotion-14.emotion-14 {
+  -webkit-transition: none!important;
+  transition: none!important;
+}
+
 <div
   class="components-select-dropdown wp-components-select-dropdown emotion-0"
   data-g2-c16t="true"
@@ -27492,6 +28084,54 @@ exports[`props should render SelectDropdown with css prop 1`] = `
           </svg>
         </div>
       </span>
+    </div>
+  </div>
+  <label
+    class="emotion-7"
+    data-g2-component="SelectDropdownLabel"
+    for="downshift-2-toggle-button"
+    id="downshift-2-label"
+  />
+  <div
+    aria-hidden="true"
+    class="emotion-8"
+    data-g2-component="SelectDropdownPopover"
+    style="width: 100%; position: absolute; left: 0px; top: 0px; margin: 0px; max-width: 0;"
+  >
+    <div
+      class="components-surface wp-components-surface components-card wp-components-card components-dropdown-menu-card wp-components-dropdown-menu-card emotion-9"
+      data-g2-c16t="true"
+      data-g2-component="SelectDropdownMenu"
+    >
+      <div
+        class="emotion-10"
+        data-g2-component="CardContent"
+      >
+        <div
+          class="components-scrollable wp-components-scrollable emotion-11"
+          data-g2-c16t="true"
+          data-g2-component="Scrollable"
+        >
+          <div
+            aria-hidden="true"
+            aria-labelledby="downshift-2-label"
+            class="emotion-12"
+            id="downshift-2-menu"
+            role="listbox"
+            tabindex="-1"
+          />
+        </div>
+      </div>
+      <div
+        class="components-elevation wp-components-elevation emotion-13"
+        data-g2-c16t="true"
+        data-g2-component="CardElevation"
+      />
+      <div
+        class="components-elevation wp-components-elevation emotion-14"
+        data-g2-c16t="true"
+        data-g2-component="CardElevation"
+      />
     </div>
   </div>
 </div>
@@ -27877,6 +28517,278 @@ exports[`props should render SelectDropdown with css prop 2`] = `
   display: block;
 }
 
+.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7 {
+  -webkit-transition: none!important;
+  transition: none!important;
+}
+
+.emotion-8.emotion-8.emotion-8.emotion-8.emotion-8.emotion-8.emotion-8 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
+  outline: none;
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-8.emotion-8.emotion-8.emotion-8.emotion-8.emotion-8.emotion-8 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-8.emotion-8.emotion-8.emotion-8.emotion-8.emotion-8.emotion-8 {
+  -webkit-transition: none!important;
+  transition: none!important;
+}
+
+.emotion-9.emotion-9.emotion-9.emotion-9.emotion-9.emotion-9.emotion-9 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
+  background-color: #ffffff;
+  background-color: var(--wp-g2-surface-color);
+  color: #1e1e1e;
+  color: var(--wp-g2-color-text);
+  position: relative;
+  --wp-g2-surface-background-size: 16px;
+  --wp-g2-surface-background-size-dotted: 15px;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 0 0 1px var(--wp-g2-surface-border-color);
+  outline: none;
+  border-radius: 2px;
+  border-radius: var(--wp-g2-card-border-radius);
+  display: none;
+  width: 100%;
+  min-width: 200px;
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-9.emotion-9.emotion-9.emotion-9.emotion-9.emotion-9.emotion-9 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-9.emotion-9.emotion-9.emotion-9.emotion-9.emotion-9.emotion-9 {
+  -webkit-transition: none!important;
+  transition: none!important;
+}
+
+.emotion-10.emotion-10.emotion-10.emotion-10.emotion-10.emotion-10.emotion-10 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
+  height: 100%;
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-10.emotion-10.emotion-10.emotion-10.emotion-10.emotion-10.emotion-10 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-10.emotion-10.emotion-10.emotion-10.emotion-10.emotion-10.emotion-10 {
+  -webkit-transition: none!important;
+  transition: none!important;
+}
+
+.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
+  height: 100%;
+  overflow-x: hidden;
+  overflow-y: auto;
+  max-height: 50vh;
+  padding: calc(4px * 1);
+  padding: calc(var(--wp-g2-grid-base) * 1);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11 {
+  -webkit-transition: none!important;
+  transition: none!important;
+}
+
+@media only screen and (min-device-width:40em) {
+  .emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11::-webkit-scrollbar {
+    height: 12px;
+    width: 12px;
+  }
+
+  .emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11::-webkit-scrollbar-track {
+    background-color: transparent;
+  }
+
+  .emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11::-webkit-scrollbar-track {
+    background: rgba(0, 0, 0, 0.04);
+    background: var(--wp-g2-color-scrollbar-track);
+    border-radius: 8px;
+  }
+
+  .emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11::-webkit-scrollbar-thumb {
+    background-clip: padding-box;
+    background-color: rgba(0, 0, 0, 0.2);
+    background-color: var(--wp-g2-color-scrollbar-thumb);
+    border: 2px solid rgba(0,0,0,0);
+    border-radius: 7px;
+  }
+
+  .emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11:hover::-webkit-scrollbar-thumb {
+    background-color: rgba(0, 0, 0, 0.5);
+    background-color: var(--wp-g2-color-scrollbar-thumb-hover);
+  }
+}
+
+.emotion-12.emotion-12.emotion-12.emotion-12.emotion-12.emotion-12.emotion-12 {
+  outline: none;
+}
+
+.emotion-13.emotion-13.emotion-13.emotion-13.emotion-13.emotion-13.emotion-13 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
+  background: transparent;
+  display: block;
+  margin: 0!important;
+  pointer-events: none;
+  position: absolute;
+  will-change: box-shadow;
+  border-radius: inherit;
+  bottom: 0;
+  box-shadow: 0 1px 2px 0 rgba(0 ,0,0,0.05);
+  opacity: 1;
+  opacity: var(--wp-g2-elevation-intensity);
+  left: 0;
+  right: 0;
+  top: 0;
+  -webkit-transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
+  -webkit-transition: box-shadow var(--wp-g2-transition-duration) var(--wp-g2-transition-timing-function);
+  transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
+  transition: box-shadow var(--wp-g2-transition-duration) var(--wp-g2-transition-timing-function);
+  border-radius: 2px;
+  border-radius: var(--wp-g2-card-border-radius);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-13.emotion-13.emotion-13.emotion-13.emotion-13.emotion-13.emotion-13 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-13.emotion-13.emotion-13.emotion-13.emotion-13.emotion-13.emotion-13 {
+  -webkit-transition: none!important;
+  transition: none!important;
+}
+
+.emotion-14.emotion-14.emotion-14.emotion-14.emotion-14.emotion-14.emotion-14 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
+  background: transparent;
+  display: block;
+  margin: 0!important;
+  pointer-events: none;
+  position: absolute;
+  will-change: box-shadow;
+  border-radius: inherit;
+  bottom: 0;
+  box-shadow: 0 3px 6px 0 rgba(0 ,0,0,0.15);
+  opacity: 1;
+  opacity: var(--wp-g2-elevation-intensity);
+  left: 0;
+  right: 0;
+  top: 0;
+  -webkit-transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
+  -webkit-transition: box-shadow var(--wp-g2-transition-duration) var(--wp-g2-transition-timing-function);
+  transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
+  transition: box-shadow var(--wp-g2-transition-duration) var(--wp-g2-transition-timing-function);
+  border-radius: 2px;
+  border-radius: var(--wp-g2-card-border-radius);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-14.emotion-14.emotion-14.emotion-14.emotion-14.emotion-14.emotion-14 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-14.emotion-14.emotion-14.emotion-14.emotion-14.emotion-14.emotion-14 {
+  -webkit-transition: none!important;
+  transition: none!important;
+}
+
 <div
   class="components-select-dropdown wp-components-select-dropdown emotion-0"
   data-g2-c16t="true"
@@ -27939,6 +28851,54 @@ exports[`props should render SelectDropdown with css prop 2`] = `
           </svg>
         </div>
       </span>
+    </div>
+  </div>
+  <label
+    class="emotion-7"
+    data-g2-component="SelectDropdownLabel"
+    for="downshift-3-toggle-button"
+    id="downshift-3-label"
+  />
+  <div
+    aria-hidden="true"
+    class="emotion-8"
+    data-g2-component="SelectDropdownPopover"
+    style="width: 100%; position: absolute; left: 0px; top: 0px; margin: 0px; max-width: 0;"
+  >
+    <div
+      class="components-surface wp-components-surface components-card wp-components-card components-dropdown-menu-card wp-components-dropdown-menu-card emotion-9"
+      data-g2-c16t="true"
+      data-g2-component="SelectDropdownMenu"
+    >
+      <div
+        class="emotion-10"
+        data-g2-component="CardContent"
+      >
+        <div
+          class="components-scrollable wp-components-scrollable emotion-11"
+          data-g2-c16t="true"
+          data-g2-component="Scrollable"
+        >
+          <div
+            aria-hidden="true"
+            aria-labelledby="downshift-3-label"
+            class="emotion-12"
+            id="downshift-3-menu"
+            role="listbox"
+            tabindex="-1"
+          />
+        </div>
+      </div>
+      <div
+        class="components-elevation wp-components-elevation emotion-13"
+        data-g2-c16t="true"
+        data-g2-component="CardElevation"
+      />
+      <div
+        class="components-elevation wp-components-elevation emotion-14"
+        data-g2-c16t="true"
+        data-g2-component="CardElevation"
+      />
     </div>
   </div>
 </div>

--- a/packages/components/src/__tests__/__snapshots__/Components.test.js.snap
+++ b/packages/components/src/__tests__/__snapshots__/Components.test.js.snap
@@ -2911,6 +2911,16 @@ exports[`props should render Badge with css prop 2`] = `
 
 exports[`props should render BaseButton 1`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2981,6 +2991,18 @@ exports[`props should render BaseButton 1`] = `
   user-select: none;
   width: auto;
   text-align: center;
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
@@ -3079,7 +3101,6 @@ exports[`props should render BaseButton 1`] = `
   data-g2-component="BaseButton"
   data-icon="false"
   id="BaseButton"
-  type="button"
 >
   <span
     class="components-elevation wp-components-elevation emotion-1"
@@ -3091,6 +3112,16 @@ exports[`props should render BaseButton 1`] = `
 
 exports[`props should render BaseButton with css prop 1`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3161,6 +3192,18 @@ exports[`props should render BaseButton with css prop 1`] = `
   user-select: none;
   width: auto;
   text-align: center;
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
@@ -3259,7 +3302,6 @@ exports[`props should render BaseButton with css prop 1`] = `
   data-g2-component="BaseButton"
   data-icon="false"
   id="BaseButton"
-  type="button"
 >
   <span
     class="components-elevation wp-components-elevation emotion-1"
@@ -3271,6 +3313,16 @@ exports[`props should render BaseButton with css prop 1`] = `
 
 exports[`props should render BaseButton with css prop 2`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3345,6 +3397,18 @@ exports[`props should render BaseButton with css prop 2`] = `
   padding: 27px;
 }
 
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
+}
+
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
   margin-left: calc(4px * 2);
   margin-left: calc(var(--wp-g2-grid-base) * 2);
@@ -3441,7 +3505,6 @@ exports[`props should render BaseButton with css prop 2`] = `
   data-g2-component="BaseButton"
   data-icon="false"
   id="BaseButton"
-  type="button"
 >
   <span
     class="components-elevation wp-components-elevation emotion-1"
@@ -3789,6 +3852,16 @@ exports[`props should render BaseModal 1`] = `null`;
 
 exports[`props should render Button 1`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3872,6 +3945,18 @@ exports[`props should render Button 1`] = `
   border-color: var(--wp-g2-button-secondary-border-color);
   color: #007cba;
   color: var(--wp-g2-button-secondary-text-color);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
@@ -4023,7 +4108,6 @@ exports[`props should render Button 1`] = `
   data-g2-component="Button"
   data-icon="false"
   id="Button"
-  type="button"
 >
   <span
     class="components-elevation wp-components-elevation emotion-1"
@@ -4035,6 +4119,16 @@ exports[`props should render Button 1`] = `
 
 exports[`props should render Button with css prop 1`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -4118,6 +4212,18 @@ exports[`props should render Button with css prop 1`] = `
   border-color: var(--wp-g2-button-secondary-border-color);
   color: #007cba;
   color: var(--wp-g2-button-secondary-text-color);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
@@ -4269,7 +4375,6 @@ exports[`props should render Button with css prop 1`] = `
   data-g2-component="Button"
   data-icon="false"
   id="Button"
-  type="button"
 >
   <span
     class="components-elevation wp-components-elevation emotion-1"
@@ -4281,6 +4386,16 @@ exports[`props should render Button with css prop 1`] = `
 
 exports[`props should render Button with css prop 2`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -4368,6 +4483,18 @@ exports[`props should render Button with css prop 2`] = `
   padding: 27px;
 }
 
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
+}
+
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
   margin-left: calc(4px * 2);
   margin-left: calc(var(--wp-g2-grid-base) * 2);
@@ -4517,7 +4644,6 @@ exports[`props should render Button with css prop 2`] = `
   data-g2-component="Button"
   data-icon="false"
   id="Button"
-  type="button"
 >
   <span
     class="components-elevation wp-components-elevation emotion-1"
@@ -6477,6 +6603,16 @@ exports[`props should render CheckboxGroup 1`] = `null`;
 
 exports[`props should render ClipboardButton 1`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6560,6 +6696,18 @@ exports[`props should render ClipboardButton 1`] = `
   border-color: var(--wp-g2-button-secondary-border-color);
   color: #007cba;
   color: var(--wp-g2-button-secondary-text-color);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
@@ -6711,7 +6859,6 @@ exports[`props should render ClipboardButton 1`] = `
   data-g2-component="ClipboardButton"
   data-icon="false"
   id="ClipboardButton"
-  type="button"
 >
   <span
     class="components-elevation wp-components-elevation emotion-1"
@@ -6723,6 +6870,16 @@ exports[`props should render ClipboardButton 1`] = `
 
 exports[`props should render ClipboardButton with css prop 1`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -6806,6 +6963,18 @@ exports[`props should render ClipboardButton with css prop 1`] = `
   border-color: var(--wp-g2-button-secondary-border-color);
   color: #007cba;
   color: var(--wp-g2-button-secondary-text-color);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
@@ -6957,7 +7126,6 @@ exports[`props should render ClipboardButton with css prop 1`] = `
   data-g2-component="ClipboardButton"
   data-icon="false"
   id="ClipboardButton"
-  type="button"
 >
   <span
     class="components-elevation wp-components-elevation emotion-1"
@@ -6969,6 +7137,16 @@ exports[`props should render ClipboardButton with css prop 1`] = `
 
 exports[`props should render ClipboardButton with css prop 2`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7056,6 +7234,18 @@ exports[`props should render ClipboardButton with css prop 2`] = `
   padding: 27px;
 }
 
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
+}
+
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
   margin-left: calc(4px * 2);
   margin-left: calc(var(--wp-g2-grid-base) * 2);
@@ -7205,7 +7395,6 @@ exports[`props should render ClipboardButton with css prop 2`] = `
   data-g2-component="ClipboardButton"
   data-icon="false"
   id="ClipboardButton"
-  type="button"
 >
   <span
     class="components-elevation wp-components-elevation emotion-1"
@@ -7217,6 +7406,16 @@ exports[`props should render ClipboardButton with css prop 2`] = `
 
 exports[`props should render CloseButton 1`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7310,6 +7509,18 @@ exports[`props should render CloseButton 1`] = `
   color: var(--wp-g2-color-text);
   padding: calc(4px * 0);
   padding: calc(var(--wp-g2-grid-base) * 0);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
@@ -7547,7 +7758,6 @@ exports[`props should render CloseButton 1`] = `
   data-g2-component="CloseButton"
   data-icon="true"
   id="CloseButton"
-  type="button"
 >
   <span
     class="components-flex-item wp-components-flex-item emotion-1"
@@ -7585,6 +7795,16 @@ exports[`props should render CloseButton 1`] = `
 
 exports[`props should render CloseButton with css prop 1`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -7678,6 +7898,18 @@ exports[`props should render CloseButton with css prop 1`] = `
   color: var(--wp-g2-color-text);
   padding: calc(4px * 0);
   padding: calc(var(--wp-g2-grid-base) * 0);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
@@ -7915,7 +8147,6 @@ exports[`props should render CloseButton with css prop 1`] = `
   data-g2-component="CloseButton"
   data-icon="true"
   id="CloseButton"
-  type="button"
 >
   <span
     class="components-flex-item wp-components-flex-item emotion-1"
@@ -7953,6 +8184,16 @@ exports[`props should render CloseButton with css prop 1`] = `
 
 exports[`props should render CloseButton with css prop 2`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8050,6 +8291,18 @@ exports[`props should render CloseButton with css prop 2`] = `
   padding: 27px;
 }
 
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
+}
+
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
   margin-left: calc(4px * 2);
   margin-left: calc(var(--wp-g2-grid-base) * 2);
@@ -8285,7 +8538,6 @@ exports[`props should render CloseButton with css prop 2`] = `
   data-g2-component="CloseButton"
   data-icon="true"
   id="CloseButton"
-  type="button"
 >
   <span
     class="components-flex-item wp-components-flex-item emotion-1"
@@ -8808,6 +9060,16 @@ exports[`props should render ColorCircle with css prop 2`] = `
 
 exports[`props should render ColorControl 1`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8917,6 +9179,18 @@ exports[`props should render ColorControl 1`] = `
   padding-left: calc(var(--wp-g2-grid-base) * 1);
   padding-right: calc(4px * 1);
   padding-right: calc(var(--wp-g2-grid-base) * 1);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
@@ -9309,7 +9583,6 @@ exports[`props should render ColorControl 1`] = `
   data-g2-component="ColorControl"
   data-icon="false"
   id="ColorControl"
-  type="button"
 >
   <span
     class="components-flex-item wp-components-flex-item emotion-1"
@@ -9361,6 +9634,16 @@ exports[`props should render ColorControl 1`] = `
 
 exports[`props should render ColorControl with css prop 1`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -9470,6 +9753,18 @@ exports[`props should render ColorControl with css prop 1`] = `
   padding-left: calc(var(--wp-g2-grid-base) * 1);
   padding-right: calc(4px * 1);
   padding-right: calc(var(--wp-g2-grid-base) * 1);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
@@ -9862,7 +10157,6 @@ exports[`props should render ColorControl with css prop 1`] = `
   data-g2-component="ColorControl"
   data-icon="false"
   id="ColorControl"
-  type="button"
 >
   <span
     class="components-flex-item wp-components-flex-item emotion-1"
@@ -9914,6 +10208,16 @@ exports[`props should render ColorControl with css prop 1`] = `
 
 exports[`props should render ColorControl with css prop 2`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -10027,6 +10331,18 @@ exports[`props should render ColorControl with css prop 2`] = `
   padding: 27px;
 }
 
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
+}
+
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
   margin-left: calc(4px * 2);
   margin-left: calc(var(--wp-g2-grid-base) * 2);
@@ -10417,7 +10733,6 @@ exports[`props should render ColorControl with css prop 2`] = `
   data-g2-component="ColorControl"
   data-icon="false"
   id="ColorControl"
-  type="button"
 >
   <span
     class="components-flex-item wp-components-flex-item emotion-1"
@@ -12336,6 +12651,16 @@ exports[`props should render DropdownMenuItem 1`] = `
   font-weight: normal;
   font-weight: var(--wp-g2-font-weight);
   margin: 0;
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -12431,6 +12756,18 @@ exports[`props should render DropdownMenuItem 1`] = `
   transition: background 100ms linear,border-color 100ms linear;
   transition: background var(--wp-g2-transition-duration-fastest) linear,border-color var(--wp-g2-transition-duration-fastest) linear;
   width: 100%;
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 @media (prefers-reduced-motion) {
@@ -12618,8 +12955,6 @@ a:active>.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0,
   data-g2-component="DropdownMenuItem"
   data-icon="false"
   id="DropdownMenuItem"
-  role="button"
-  tabindex="0"
 >
   <span
     class="components-elevation wp-components-elevation emotion-1"
@@ -12641,6 +12976,16 @@ exports[`props should render DropdownMenuItem with css prop 1`] = `
   font-weight: normal;
   font-weight: var(--wp-g2-font-weight);
   margin: 0;
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -12736,6 +13081,18 @@ exports[`props should render DropdownMenuItem with css prop 1`] = `
   transition: background 100ms linear,border-color 100ms linear;
   transition: background var(--wp-g2-transition-duration-fastest) linear,border-color var(--wp-g2-transition-duration-fastest) linear;
   width: 100%;
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 @media (prefers-reduced-motion) {
@@ -12923,8 +13280,6 @@ a:active>.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0,
   data-g2-component="DropdownMenuItem"
   data-icon="false"
   id="DropdownMenuItem"
-  role="button"
-  tabindex="0"
 >
   <span
     class="components-elevation wp-components-elevation emotion-1"
@@ -12946,6 +13301,16 @@ exports[`props should render DropdownMenuItem with css prop 2`] = `
   font-weight: normal;
   font-weight: var(--wp-g2-font-weight);
   margin: 0;
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -13043,6 +13408,18 @@ exports[`props should render DropdownMenuItem with css prop 2`] = `
   width: 100%;
   background: red;
   padding: 27px;
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 @media (prefers-reduced-motion) {
@@ -13230,8 +13607,6 @@ a:active>.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0,
   data-g2-component="DropdownMenuItem"
   data-icon="false"
   id="DropdownMenuItem"
-  role="button"
-  tabindex="0"
 >
   <span
     class="components-elevation wp-components-elevation emotion-1"
@@ -13243,6 +13618,16 @@ a:active>.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0,
 
 exports[`props should render DropdownTrigger 1`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -13326,6 +13711,18 @@ exports[`props should render DropdownTrigger 1`] = `
   border-color: var(--wp-g2-button-secondary-border-color);
   color: #007cba;
   color: var(--wp-g2-button-secondary-text-color);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
@@ -13477,7 +13874,6 @@ exports[`props should render DropdownTrigger 1`] = `
   data-g2-component="DropdownTrigger"
   data-icon="false"
   id="DropdownTrigger"
-  type="button"
 >
   <span
     class="components-elevation wp-components-elevation emotion-1"
@@ -13489,6 +13885,16 @@ exports[`props should render DropdownTrigger 1`] = `
 
 exports[`props should render DropdownTrigger with css prop 1`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -13572,6 +13978,18 @@ exports[`props should render DropdownTrigger with css prop 1`] = `
   border-color: var(--wp-g2-button-secondary-border-color);
   color: #007cba;
   color: var(--wp-g2-button-secondary-text-color);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
@@ -13723,7 +14141,6 @@ exports[`props should render DropdownTrigger with css prop 1`] = `
   data-g2-component="DropdownTrigger"
   data-icon="false"
   id="DropdownTrigger"
-  type="button"
 >
   <span
     class="components-elevation wp-components-elevation emotion-1"
@@ -13735,6 +14152,16 @@ exports[`props should render DropdownTrigger with css prop 1`] = `
 
 exports[`props should render DropdownTrigger with css prop 2`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -13822,6 +14249,18 @@ exports[`props should render DropdownTrigger with css prop 2`] = `
   padding: 27px;
 }
 
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
+}
+
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
   margin-left: calc(4px * 2);
   margin-left: calc(var(--wp-g2-grid-base) * 2);
@@ -13971,7 +14410,6 @@ exports[`props should render DropdownTrigger with css prop 2`] = `
   data-g2-component="DropdownTrigger"
   data-icon="false"
   id="DropdownTrigger"
-  type="button"
 >
   <span
     class="components-elevation wp-components-elevation emotion-1"
@@ -15619,6 +16057,16 @@ exports[`props should render FontSizeControl 1`] = `
 }
 
 .emotion-13.emotion-13.emotion-13.emotion-13.emotion-13.emotion-13.emotion-13 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -15707,6 +16155,18 @@ exports[`props should render FontSizeControl 1`] = `
   border-color: var(--wp-g2-button-secondary-border-color);
   color: #007cba;
   color: var(--wp-g2-button-secondary-text-color);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-13.emotion-13.emotion-13.emotion-13.emotion-13.emotion-13.emotion-13 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-13.emotion-13.emotion-13.emotion-13.emotion-13.emotion-13.emotion-13 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-13.emotion-13.emotion-13.emotion-13.emotion-13.emotion-13.emotion-13>*+*:not(marquee) {
@@ -16001,7 +16461,6 @@ exports[`props should render FontSizeControl 1`] = `
         >
           <button
             aria-busy="false"
-            aria-disabled="true"
             class="components-flex wp-components-flex components-base-button wp-components-base-button components-button wp-components-button emotion-13"
             data-active="false"
             data-destructive="false"
@@ -16010,8 +16469,6 @@ exports[`props should render FontSizeControl 1`] = `
             data-g2-component="Button"
             data-icon="false"
             disabled=""
-            style="pointer-events: none;"
-            type="button"
           >
             <span
               class="components-flex-item wp-components-flex-item emotion-14"
@@ -16692,6 +17149,16 @@ exports[`props should render FontSizeControl with css prop 1`] = `
 }
 
 .emotion-13.emotion-13.emotion-13.emotion-13.emotion-13.emotion-13.emotion-13 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -16780,6 +17247,18 @@ exports[`props should render FontSizeControl with css prop 1`] = `
   border-color: var(--wp-g2-button-secondary-border-color);
   color: #007cba;
   color: var(--wp-g2-button-secondary-text-color);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-13.emotion-13.emotion-13.emotion-13.emotion-13.emotion-13.emotion-13 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-13.emotion-13.emotion-13.emotion-13.emotion-13.emotion-13.emotion-13 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-13.emotion-13.emotion-13.emotion-13.emotion-13.emotion-13.emotion-13>*+*:not(marquee) {
@@ -17074,7 +17553,6 @@ exports[`props should render FontSizeControl with css prop 1`] = `
         >
           <button
             aria-busy="false"
-            aria-disabled="true"
             class="components-flex wp-components-flex components-base-button wp-components-base-button components-button wp-components-button emotion-13"
             data-active="false"
             data-destructive="false"
@@ -17083,8 +17561,6 @@ exports[`props should render FontSizeControl with css prop 1`] = `
             data-g2-component="Button"
             data-icon="false"
             disabled=""
-            style="pointer-events: none;"
-            type="button"
           >
             <span
               class="components-flex-item wp-components-flex-item emotion-14"
@@ -17767,6 +18243,16 @@ exports[`props should render FontSizeControl with css prop 2`] = `
 }
 
 .emotion-13.emotion-13.emotion-13.emotion-13.emotion-13.emotion-13.emotion-13 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -17855,6 +18341,18 @@ exports[`props should render FontSizeControl with css prop 2`] = `
   border-color: var(--wp-g2-button-secondary-border-color);
   color: #007cba;
   color: var(--wp-g2-button-secondary-text-color);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-13.emotion-13.emotion-13.emotion-13.emotion-13.emotion-13.emotion-13 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-13.emotion-13.emotion-13.emotion-13.emotion-13.emotion-13.emotion-13 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-13.emotion-13.emotion-13.emotion-13.emotion-13.emotion-13.emotion-13>*+*:not(marquee) {
@@ -18149,7 +18647,6 @@ exports[`props should render FontSizeControl with css prop 2`] = `
         >
           <button
             aria-busy="false"
-            aria-disabled="true"
             class="components-flex wp-components-flex components-base-button wp-components-base-button components-button wp-components-button emotion-13"
             data-active="false"
             data-destructive="false"
@@ -18158,8 +18655,6 @@ exports[`props should render FontSizeControl with css prop 2`] = `
             data-g2-component="Button"
             data-icon="false"
             disabled=""
-            style="pointer-events: none;"
-            type="button"
           >
             <span
               class="components-flex-item wp-components-flex-item emotion-14"
@@ -20639,6 +21134,16 @@ exports[`props should render MenuItem 1`] = `
   font-weight: normal;
   font-weight: var(--wp-g2-font-weight);
   margin: 0;
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -20734,6 +21239,18 @@ exports[`props should render MenuItem 1`] = `
   transition: background 100ms linear,border-color 100ms linear;
   transition: background var(--wp-g2-transition-duration-fastest) linear,border-color var(--wp-g2-transition-duration-fastest) linear;
   width: 100%;
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 @media (prefers-reduced-motion) {
@@ -20921,8 +21438,6 @@ a:active>.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0,
   data-g2-component="MenuItem"
   data-icon="false"
   id="MenuItem"
-  role="button"
-  tabindex="0"
 >
   <span
     class="components-elevation wp-components-elevation emotion-1"
@@ -20944,6 +21459,16 @@ exports[`props should render MenuItem with css prop 1`] = `
   font-weight: normal;
   font-weight: var(--wp-g2-font-weight);
   margin: 0;
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -21039,6 +21564,18 @@ exports[`props should render MenuItem with css prop 1`] = `
   transition: background 100ms linear,border-color 100ms linear;
   transition: background var(--wp-g2-transition-duration-fastest) linear,border-color var(--wp-g2-transition-duration-fastest) linear;
   width: 100%;
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 @media (prefers-reduced-motion) {
@@ -21226,8 +21763,6 @@ a:active>.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0,
   data-g2-component="MenuItem"
   data-icon="false"
   id="MenuItem"
-  role="button"
-  tabindex="0"
 >
   <span
     class="components-elevation wp-components-elevation emotion-1"
@@ -21239,6 +21774,16 @@ a:active>.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0,
 
 exports[`props should render MenuItem with css prop 2`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   box-sizing: border-box;
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
@@ -21360,6 +21905,18 @@ exports[`props should render MenuItem with css prop 2`] = `
   transition: none!important;
 }
 
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
+}
+
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
   margin-left: calc(4px * 2);
   margin-left: calc(var(--wp-g2-grid-base) * 2);
@@ -21533,8 +22090,6 @@ a:active>.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0,
   data-g2-component="MenuItem"
   data-icon="false"
   id="MenuItem"
-  role="button"
-  tabindex="0"
 >
   <span
     class="components-elevation wp-components-elevation emotion-1"
@@ -22196,6 +22751,16 @@ exports[`props should render ModalHeader 1`] = `
 }
 
 .emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -22281,6 +22846,18 @@ exports[`props should render ModalHeader 1`] = `
   border-color: transparent;
   color: #007cba;
   color: var(--wp-g2-link-color);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2>*+*:not(marquee) {
@@ -22447,7 +23024,6 @@ exports[`props should render ModalHeader 1`] = `
       data-g2-c16t="true"
       data-g2-component="Button"
       data-icon="false"
-      type="button"
     >
       <span
         class="components-flex-item wp-components-flex-item emotion-3"
@@ -22584,6 +23160,16 @@ exports[`props should render ModalHeader with css prop 1`] = `
 }
 
 .emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -22669,6 +23255,18 @@ exports[`props should render ModalHeader with css prop 1`] = `
   border-color: transparent;
   color: #007cba;
   color: var(--wp-g2-link-color);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2>*+*:not(marquee) {
@@ -22835,7 +23433,6 @@ exports[`props should render ModalHeader with css prop 1`] = `
       data-g2-c16t="true"
       data-g2-component="Button"
       data-icon="false"
-      type="button"
     >
       <span
         class="components-flex-item wp-components-flex-item emotion-3"
@@ -22974,6 +23571,16 @@ exports[`props should render ModalHeader with css prop 2`] = `
 }
 
 .emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -23059,6 +23666,18 @@ exports[`props should render ModalHeader with css prop 2`] = `
   border-color: transparent;
   color: #007cba;
   color: var(--wp-g2-link-color);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2>*+*:not(marquee) {
@@ -23225,7 +23844,6 @@ exports[`props should render ModalHeader with css prop 2`] = `
       data-g2-c16t="true"
       data-g2-component="Button"
       data-icon="false"
-      type="button"
     >
       <span
         class="components-flex-item wp-components-flex-item emotion-3"
@@ -23248,6 +23866,16 @@ exports[`props should render ModalTitle 1`] = `null`;
 
 exports[`props should render ModalTrigger 1`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -23331,6 +23959,18 @@ exports[`props should render ModalTrigger 1`] = `
   border-color: var(--wp-g2-button-secondary-border-color);
   color: #007cba;
   color: var(--wp-g2-button-secondary-text-color);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
@@ -23496,6 +24136,16 @@ exports[`props should render ModalTrigger 1`] = `
 
 exports[`props should render NavigatorButton 1`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -23579,6 +24229,18 @@ exports[`props should render NavigatorButton 1`] = `
   border-color: var(--wp-g2-button-secondary-border-color);
   color: #007cba;
   color: var(--wp-g2-button-secondary-text-color);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
@@ -23742,6 +24404,16 @@ exports[`props should render NavigatorButton 1`] = `
 
 exports[`props should render NavigatorButton with css prop 1`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -23825,6 +24497,18 @@ exports[`props should render NavigatorButton with css prop 1`] = `
   border-color: var(--wp-g2-button-secondary-border-color);
   color: #007cba;
   color: var(--wp-g2-button-secondary-text-color);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
@@ -23988,6 +24672,16 @@ exports[`props should render NavigatorButton with css prop 1`] = `
 
 exports[`props should render NavigatorButton with css prop 2`] = `
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -24073,6 +24767,18 @@ exports[`props should render NavigatorButton with css prop 2`] = `
   color: var(--wp-g2-button-secondary-text-color);
   background: red;
   padding: 27px;
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0>*+*:not(marquee) {
@@ -25437,6 +26143,16 @@ exports[`props should render SearchInput 1`] = `
 }
 
 .emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -25533,6 +26249,18 @@ exports[`props should render SearchInput 1`] = `
   min-height: var(--wp-g2-control-height-xx-small);
   padding: calc(4px * 0);
   padding: calc(var(--wp-g2-grid-base) * 0);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6.emotion-6>*+*:not(marquee) {
@@ -25817,7 +26545,6 @@ exports[`props should render SearchInput 1`] = `
       data-g2-component="Button"
       data-icon="true"
       tabindex="-1"
-      type="button"
     >
       <span
         class="components-flex-item wp-components-flex-item emotion-7"
@@ -30442,6 +31169,16 @@ exports[`props should render Stepper 1`] = `
 }
 
 .emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -30549,6 +31286,18 @@ exports[`props should render Stepper 1`] = `
   font-size: var(--wp-g2-font-size);
   padding: calc(4px * 0);
   padding: calc(var(--wp-g2-grid-base) * 0);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1>*+*:not(marquee) {
@@ -30783,6 +31532,16 @@ exports[`props should render Stepper 1`] = `
 }
 
 .emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -30890,6 +31649,18 @@ exports[`props should render Stepper 1`] = `
   font-size: var(--wp-g2-font-size);
   padding: calc(4px * 0);
   padding: calc(var(--wp-g2-grid-base) * 0);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5>*+*:not(marquee) {
@@ -31017,7 +31788,6 @@ exports[`props should render Stepper 1`] = `
     data-g2-c16t="true"
     data-g2-component="StepperButton"
     data-icon="true"
-    type="button"
   >
     <span
       class="components-flex-item wp-components-flex-item emotion-2"
@@ -31060,7 +31830,6 @@ exports[`props should render Stepper 1`] = `
     data-g2-c16t="true"
     data-g2-component="StepperButton"
     data-icon="true"
-    type="button"
   >
     <span
       class="components-flex-item wp-components-flex-item emotion-2"
@@ -31163,6 +31932,16 @@ exports[`props should render Stepper with css prop 1`] = `
 }
 
 .emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -31270,6 +32049,18 @@ exports[`props should render Stepper with css prop 1`] = `
   font-size: var(--wp-g2-font-size);
   padding: calc(4px * 0);
   padding: calc(var(--wp-g2-grid-base) * 0);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1>*+*:not(marquee) {
@@ -31504,6 +32295,16 @@ exports[`props should render Stepper with css prop 1`] = `
 }
 
 .emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -31611,6 +32412,18 @@ exports[`props should render Stepper with css prop 1`] = `
   font-size: var(--wp-g2-font-size);
   padding: calc(4px * 0);
   padding: calc(var(--wp-g2-grid-base) * 0);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5>*+*:not(marquee) {
@@ -31738,7 +32551,6 @@ exports[`props should render Stepper with css prop 1`] = `
     data-g2-c16t="true"
     data-g2-component="StepperButton"
     data-icon="true"
-    type="button"
   >
     <span
       class="components-flex-item wp-components-flex-item emotion-2"
@@ -31781,7 +32593,6 @@ exports[`props should render Stepper with css prop 1`] = `
     data-g2-c16t="true"
     data-g2-component="StepperButton"
     data-icon="true"
-    type="button"
   >
     <span
       class="components-flex-item wp-components-flex-item emotion-2"
@@ -31886,6 +32697,16 @@ exports[`props should render Stepper with css prop 2`] = `
 }
 
 .emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -31993,6 +32814,18 @@ exports[`props should render Stepper with css prop 2`] = `
   font-size: var(--wp-g2-font-size);
   padding: calc(4px * 0);
   padding: calc(var(--wp-g2-grid-base) * 0);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1.emotion-1>*+*:not(marquee) {
@@ -32227,6 +33060,16 @@ exports[`props should render Stepper with css prop 2`] = `
 }
 
 .emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -32334,6 +33177,18 @@ exports[`props should render Stepper with css prop 2`] = `
   font-size: var(--wp-g2-font-size);
   padding: calc(4px * 0);
   padding: calc(var(--wp-g2-grid-base) * 0);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5 {
+  -webkit-transition: none!important;
+  transition: none!important;
 }
 
 .emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5.emotion-5>*+*:not(marquee) {
@@ -32461,7 +33316,6 @@ exports[`props should render Stepper with css prop 2`] = `
     data-g2-c16t="true"
     data-g2-component="StepperButton"
     data-icon="true"
-    type="button"
   >
     <span
       class="components-flex-item wp-components-flex-item emotion-2"
@@ -32504,7 +33358,6 @@ exports[`props should render Stepper with css prop 2`] = `
     data-g2-c16t="true"
     data-g2-component="StepperButton"
     data-icon="true"
-    type="button"
   >
     <span
       class="components-flex-item wp-components-flex-item emotion-2"

--- a/packages/components/src/select-dropdown/__tests__/__snapshots__/index.js.snap
+++ b/packages/components/src/select-dropdown/__tests__/__snapshots__/index.js.snap
@@ -378,6 +378,278 @@ exports[`props should render correctly 1`] = `
   display: block;
 }
 
+.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7.emotion-7 {
+  -webkit-transition: none!important;
+  transition: none!important;
+}
+
+.emotion-8.emotion-8.emotion-8.emotion-8.emotion-8.emotion-8.emotion-8 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
+  outline: none;
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-8.emotion-8.emotion-8.emotion-8.emotion-8.emotion-8.emotion-8 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-8.emotion-8.emotion-8.emotion-8.emotion-8.emotion-8.emotion-8 {
+  -webkit-transition: none!important;
+  transition: none!important;
+}
+
+.emotion-9.emotion-9.emotion-9.emotion-9.emotion-9.emotion-9.emotion-9 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
+  background-color: #ffffff;
+  background-color: var(--wp-g2-surface-color);
+  color: #1e1e1e;
+  color: var(--wp-g2-color-text);
+  position: relative;
+  --wp-g2-surface-background-size: 16px;
+  --wp-g2-surface-background-size-dotted: 15px;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 0 0 1px var(--wp-g2-surface-border-color);
+  outline: none;
+  border-radius: 2px;
+  border-radius: var(--wp-g2-card-border-radius);
+  display: none;
+  width: 100%;
+  min-width: 200px;
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-9.emotion-9.emotion-9.emotion-9.emotion-9.emotion-9.emotion-9 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-9.emotion-9.emotion-9.emotion-9.emotion-9.emotion-9.emotion-9 {
+  -webkit-transition: none!important;
+  transition: none!important;
+}
+
+.emotion-10.emotion-10.emotion-10.emotion-10.emotion-10.emotion-10.emotion-10 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
+  height: 100%;
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-10.emotion-10.emotion-10.emotion-10.emotion-10.emotion-10.emotion-10 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-10.emotion-10.emotion-10.emotion-10.emotion-10.emotion-10.emotion-10 {
+  -webkit-transition: none!important;
+  transition: none!important;
+}
+
+.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
+  height: 100%;
+  overflow-x: hidden;
+  overflow-y: auto;
+  max-height: 50vh;
+  padding: calc(4px * 1);
+  padding: calc(var(--wp-g2-grid-base) * 1);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11 {
+  -webkit-transition: none!important;
+  transition: none!important;
+}
+
+@media only screen and (min-device-width:40em) {
+  .emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11::-webkit-scrollbar {
+    height: 12px;
+    width: 12px;
+  }
+
+  .emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11::-webkit-scrollbar-track {
+    background-color: transparent;
+  }
+
+  .emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11::-webkit-scrollbar-track {
+    background: rgba(0, 0, 0, 0.04);
+    background: var(--wp-g2-color-scrollbar-track);
+    border-radius: 8px;
+  }
+
+  .emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11::-webkit-scrollbar-thumb {
+    background-clip: padding-box;
+    background-color: rgba(0, 0, 0, 0.2);
+    background-color: var(--wp-g2-color-scrollbar-thumb);
+    border: 2px solid rgba(0,0,0,0);
+    border-radius: 7px;
+  }
+
+  .emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11.emotion-11:hover::-webkit-scrollbar-thumb {
+    background-color: rgba(0, 0, 0, 0.5);
+    background-color: var(--wp-g2-color-scrollbar-thumb-hover);
+  }
+}
+
+.emotion-12.emotion-12.emotion-12.emotion-12.emotion-12.emotion-12.emotion-12 {
+  outline: none;
+}
+
+.emotion-13.emotion-13.emotion-13.emotion-13.emotion-13.emotion-13.emotion-13 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
+  background: transparent;
+  display: block;
+  margin: 0!important;
+  pointer-events: none;
+  position: absolute;
+  will-change: box-shadow;
+  border-radius: inherit;
+  bottom: 0;
+  box-shadow: 0 1px 2px 0 rgba(0 ,0,0,0.05);
+  opacity: 1;
+  opacity: var(--wp-g2-elevation-intensity);
+  left: 0;
+  right: 0;
+  top: 0;
+  -webkit-transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
+  -webkit-transition: box-shadow var(--wp-g2-transition-duration) var(--wp-g2-transition-timing-function);
+  transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
+  transition: box-shadow var(--wp-g2-transition-duration) var(--wp-g2-transition-timing-function);
+  border-radius: 2px;
+  border-radius: var(--wp-g2-card-border-radius);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-13.emotion-13.emotion-13.emotion-13.emotion-13.emotion-13.emotion-13 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-13.emotion-13.emotion-13.emotion-13.emotion-13.emotion-13.emotion-13 {
+  -webkit-transition: none!important;
+  transition: none!important;
+}
+
+.emotion-14.emotion-14.emotion-14.emotion-14.emotion-14.emotion-14.emotion-14 {
+  box-sizing: border-box;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-family: Inter,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",sans-serif;
+  font-family: var(--wp-g2-font-family);
+  font-size: 13px;
+  font-size: var(--wp-g2-font-size);
+  font-weight: normal;
+  font-weight: var(--wp-g2-font-weight);
+  margin: 0;
+  background: transparent;
+  display: block;
+  margin: 0!important;
+  pointer-events: none;
+  position: absolute;
+  will-change: box-shadow;
+  border-radius: inherit;
+  bottom: 0;
+  box-shadow: 0 3px 6px 0 rgba(0 ,0,0,0.15);
+  opacity: 1;
+  opacity: var(--wp-g2-elevation-intensity);
+  left: 0;
+  right: 0;
+  top: 0;
+  -webkit-transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
+  -webkit-transition: box-shadow var(--wp-g2-transition-duration) var(--wp-g2-transition-timing-function);
+  transition: box-shadow 200ms cubic-bezier(0.08, 0.52, 0.52, 1);
+  transition: box-shadow var(--wp-g2-transition-duration) var(--wp-g2-transition-timing-function);
+  border-radius: 2px;
+  border-radius: var(--wp-g2-card-border-radius);
+}
+
+@media (prefers-reduced-motion) {
+  .emotion-14.emotion-14.emotion-14.emotion-14.emotion-14.emotion-14.emotion-14 {
+    -webkit-transition: none!important;
+    transition: none!important;
+  }
+}
+
+[data-system-ui-reduced-motion-mode="true"] .emotion-14.emotion-14.emotion-14.emotion-14.emotion-14.emotion-14.emotion-14 {
+  -webkit-transition: none!important;
+  transition: none!important;
+}
+
 <div
   class="components-select-dropdown wp-components-select-dropdown emotion-0"
   data-g2-c16t="true"
@@ -439,6 +711,54 @@ exports[`props should render correctly 1`] = `
           </svg>
         </div>
       </span>
+    </div>
+  </div>
+  <label
+    class="emotion-7"
+    data-g2-component="SelectDropdownLabel"
+    for="downshift-0-toggle-button"
+    id="downshift-0-label"
+  />
+  <div
+    aria-hidden="true"
+    class="emotion-8"
+    data-g2-component="SelectDropdownPopover"
+    style="width: 100%; position: absolute; left: 0px; top: 0px; margin: 0px; max-width: 0;"
+  >
+    <div
+      class="components-surface wp-components-surface components-card wp-components-card components-dropdown-menu-card wp-components-dropdown-menu-card emotion-9"
+      data-g2-c16t="true"
+      data-g2-component="SelectDropdownMenu"
+    >
+      <div
+        class="emotion-10"
+        data-g2-component="CardContent"
+      >
+        <div
+          class="components-scrollable wp-components-scrollable emotion-11"
+          data-g2-c16t="true"
+          data-g2-component="Scrollable"
+        >
+          <div
+            aria-hidden="true"
+            aria-labelledby="downshift-0-label"
+            class="emotion-12"
+            id="downshift-0-menu"
+            role="listbox"
+            tabindex="-1"
+          />
+        </div>
+      </div>
+      <div
+        class="components-elevation wp-components-elevation emotion-13"
+        data-g2-c16t="true"
+        data-g2-component="CardElevation"
+      />
+      <div
+        class="components-elevation wp-components-elevation emotion-14"
+        data-g2-c16t="true"
+        data-g2-component="CardElevation"
+      />
     </div>
   </div>
 </div>

--- a/packages/components/src/select-dropdown/select-dropdown-styles.js
+++ b/packages/components/src/select-dropdown/select-dropdown-styles.js
@@ -14,4 +14,8 @@ export const DropdownMenu = css`
 	width: 100%;
 `;
 
+export const hidden = css`
+	display: none;
+`;
+
 export const inline = baseFieldStyles.inline;

--- a/packages/components/src/select-dropdown/select-dropdown.js
+++ b/packages/components/src/select-dropdown/select-dropdown.js
@@ -18,6 +18,7 @@ function SelectDropdown(props, forwardedRef) {
 		items,
 		label,
 		labelProps,
+		menuProps,
 		placeholder,
 		popoverProps,
 		popoverRef,
@@ -33,18 +34,20 @@ function SelectDropdown(props, forwardedRef) {
 			<Select as="button" {...referenceProps}>
 				<Truncate>{referenceProps.children}</Truncate>
 			</Select>
-			<Portal>
-				<View {...popoverProps}>
-					<SelectDropdownLabel {...labelProps} />
-					{isOpen && (
-						<DropdownMenuCard {...dropdownMenuProps}>
-							{items.map((item) => (
-								<SelectDropdownItem {...item} />
-							))}
-						</DropdownMenuCard>
-					)}
-				</View>
-			</Portal>
+			<SelectDropdownLabel {...labelProps} />
+			<View {...popoverProps}>
+				<DropdownMenuCard {...dropdownMenuProps}>
+					<div {...menuProps}>
+						{isOpen && (
+							<>
+								{items.map((item) => (
+									<SelectDropdownItem {...item} />
+								))}
+							</>
+						)}
+					</div>
+				</DropdownMenuCard>
+			</View>
 		</View>
 	);
 }

--- a/packages/components/src/select-dropdown/use-select-dropdown.js
+++ b/packages/components/src/select-dropdown/use-select-dropdown.js
@@ -1,11 +1,6 @@
 import { useContextSystem } from '@wp-g2/context';
 import { css, cx, ui } from '@wp-g2/styles';
-import {
-	mergeRefs,
-	noop,
-	useResizeAware,
-	useUpdateEffect,
-} from '@wp-g2/utils';
+import { mergeRefs, noop, useResizeAware, useUpdateEffect } from '@wp-g2/utils';
 import { useSelect } from 'downshift';
 import { useState } from 'react';
 import { useCallback, useEffect, useRef } from 'react';
@@ -164,30 +159,30 @@ export function useSelectDropdown(props) {
 		onClose();
 	}, [focusSelectButton, onClose]);
 
-	const _popoverProps = getMenuProps({
-		...ui.$('SelectDropdownPopover'),
+	const menuProps = getMenuProps({
 		className: styles.MenuWrapper,
 		'aria-hidden': !isOpen,
+	});
+
+	// We need this here, because the null active descendant is not
+	// fully ARIA compliant.
+	if (
+		menuProps['aria-activedescendant'] &&
+		menuProps['aria-activedescendant'].slice(0, 'downshift-null'.length) ===
+			'downshift-null'
+	) {
+		delete menuProps['aria-activedescendant'];
+	}
+
+	const popoverProps = {
+		...ui.$('SelectDropdownPopover'),
+		'aria-hidden': !isOpen,
+		className: styles.MenuWrapper,
+		ref: popoverRef,
 		style: {
 			maxWidth: isInline ? maxWidthProp : sizes.width,
 			width: isInline ? null : '100%',
 		},
-	});
-	// We need this here, because the null active descendant is not
-	// fully ARIA compliant.
-	if (
-		_popoverProps['aria-activedescendant'] &&
-		_popoverProps['aria-activedescendant'].slice(
-			0,
-			'downshift-null'.length,
-		) === 'downshift-null'
-	) {
-		delete _popoverProps['aria-activedescendant'];
-	}
-
-	const popoverProps = {
-		..._popoverProps,
-		ref: mergeRefs([_popoverProps.ref, popoverRef]),
 	};
 
 	const _referenceProps = getToggleButtonProps({
@@ -234,7 +229,11 @@ export function useSelectDropdown(props) {
 
 	const dropdownMenuProps = {
 		...ui.$('SelectDropdownMenu'),
-		className: cx(styles.DropdownMenu, css({ minWidth })),
+		className: cx(
+			!isOpen && styles.hidden,
+			styles.DropdownMenu,
+			css({ minWidth }),
+		),
 	};
 
 	/**
@@ -254,6 +253,7 @@ export function useSelectDropdown(props) {
 		labelProps,
 		popoverProps,
 		resizer,
+		menuProps,
 		referenceProps,
 		items: enhancedItems,
 		isOpen,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5817,11 +5817,6 @@
     lodash "^4.17.19"
     rungen "^0.3.2"
 
-"@wordpress/warning@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/warning/-/warning-1.3.0.tgz#9254f77b0cc79b1b356c93d2b726be78d82588ad"
-  integrity sha512-xwvgwqugc3zQawSPMMA09knAgap7IGgp0PxTXpFqizGFRIohoXFWERnPBZT0VsSCovqYS0ADcH+ZZgQ+BKAzLA==
-
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"


### PR DESCRIPTION
<img width="527" alt="Screen Shot 2021-01-21 at 9 10 40 AM" src="https://user-images.githubusercontent.com/2322354/105380438-ddad0000-5bdb-11eb-81ac-187c5692a8b4.png">


This update fixes the a11y voiceover handling for the `SelectDropdown` component, which powers components like the `FontSizePicker`.

This was discovered after the integration of the `FontSizePicker` into Gutenberg:
https://github.com/WordPress/gutenberg/pull/27594

<img width="519" alt="Screen Shot 2021-01-21 at 8 56 23 AM" src="https://user-images.githubusercontent.com/2322354/105380452-e1d91d80-5bdb-11eb-9016-cac41a8f1f90.png">

The solution was the adjust the render structure for the `SelectDropdown` to better accommodate `useSelect()` from `downshift` (the same library/setup we use on the [`custom-select-control`](https://github.com/WordPress/gutenberg/tree/master/packages/components/src/custom-select-control).

Unfortunately, we do lose the ability to `Portal` the menu content with this adjustment. It's more important that voiceover works correctly though.

We can revisit `useSelect` + portal'ing in the future.
From my experience, this doesn't seem like a very straight forward thing to do.

Other adjustments would be for the `TextInput`.
It's been adjusted so that `isCommitOnBlurOrEnter` is defaulted to `false`, matching the interaction flow for standard inputs and inputs found in the `@wordpress/components` library.

We can revisit the `input[type="number"]` interactions for `FontSizePicker` in the future.

---

### Testing

The quickest way to test would be to visit this URL:
https://g2-git-fix-select-dropdown-a11y.itsjonq.vercel.app/iframe.html?id=components-fontsizecontrol--periodic-rerender&viewMode=story

Turn on Mac OS voiceover to ensure that the focus and selections are working as expected.

--

cc'ing @talldan