### PR TITLE
SelectDropdown: Ensure initial aria-expanded is rendered in reference element

### DIFF
--- a/packages/components/src/__tests__/__snapshots__/Components.test.js.snap
+++ b/packages/components/src/__tests__/__snapshots__/Components.test.js.snap
@@ -28023,6 +28023,7 @@ exports[`props should render SelectDropdown 1`] = `
     data-g2-component="SelectWrapper"
   >
     <button
+      aria-expanded="false"
       aria-haspopup="listbox"
       class="emotion-2"
       data-g2-c16t="true"
@@ -28794,6 +28795,7 @@ exports[`props should render SelectDropdown with css prop 1`] = `
     data-g2-component="SelectWrapper"
   >
     <button
+      aria-expanded="false"
       aria-haspopup="listbox"
       class="emotion-2"
       data-g2-c16t="true"
@@ -29567,6 +29569,7 @@ exports[`props should render SelectDropdown with css prop 2`] = `
     data-g2-component="SelectWrapper"
   >
     <button
+      aria-expanded="false"
       aria-haspopup="listbox"
       class="emotion-2"
       data-g2-c16t="true"

--- a/packages/components/src/select-dropdown/__tests__/__snapshots__/index.js.snap
+++ b/packages/components/src/select-dropdown/__tests__/__snapshots__/index.js.snap
@@ -674,6 +674,7 @@ exports[`props should render correctly 1`] = `
     data-g2-component="SelectWrapper"
   >
     <button
+      aria-expanded="false"
       aria-haspopup="listbox"
       class="emotion-2"
       data-g2-c16t="true"

--- a/packages/components/src/select-dropdown/use-select-dropdown.js
+++ b/packages/components/src/select-dropdown/use-select-dropdown.js
@@ -193,6 +193,7 @@ export function useSelectDropdown(props) {
 	const referenceProps = {
 		...ui.$('SelectDropdownReference'),
 		..._referenceProps,
+		'aria-expanded': !!isOpen,
 		children: itemToString(selectedItem) || placeholder,
 		error,
 		id,


### PR DESCRIPTION
<img width="506" alt="Screen Shot 2021-01-22 at 10 41 24 AM" src="https://user-images.githubusercontent.com/2322354/105512840-9ab46080-5c9f-11eb-8d06-b44f7170c4ac.png">

This update fixes the `downshift` `useSelect` integration with `SelectDropdown`.
Previously, `aria-expanded` would only be added after an interaction with the dropdown.
We need the reference element (`button`) to have `aria-expanded` from it's initial render.