### PR TITLE
Flex, HStack, FontSizePicker: Improve responsive rendering for longer translation labels

### DIFF
--- a/packages/components/src/Flex/Flex.styles.js
+++ b/packages/components/src/Flex/Flex.styles.js
@@ -15,3 +15,27 @@ export const Item = css`
 export const block = css`
 	flex: 1;
 `;
+
+/**
+ * Workaround to optimize DOM rendering.
+ * We'll enhance alignment with naive parent flex assumptions.
+ *
+ * Trade-off:
+ * Far less DOM less. However, UI rendering is not as reliable.
+ */
+
+/**
+ * Improves stability of width/height rendering.
+ * https://github.com/ItsJonQ/g2/pull/149
+ */
+export const ItemsColumn = css`
+	> * {
+		min-height: 0;
+	}
+`;
+
+export const ItemsRow = css`
+	> * {
+		min-width: 0;
+	}
+`;

--- a/packages/components/src/Flex/useFlex.js
+++ b/packages/components/src/Flex/useFlex.js
@@ -59,6 +59,10 @@ export function useFlex(props) {
 			justifyContent: justifyContent || justify,
 			height: isColumn && expanded ? '100%' : undefined,
 			width: !isColumn && expanded ? '100%' : undefined,
+			marginBottom: wrap ? `calc(${ui.space(gap)} * -1)` : null,
+		});
+
+		sx.Items = css({
 			/**
 			 * Workaround to optimize DOM rendering.
 			 * We'll enhance alignment with naive parent flex assumptions.
@@ -71,17 +75,28 @@ export function useFlex(props) {
 				marginRight: !isColumn && isReverse ? ui.space(gap) : undefined,
 				marginLeft: !isColumn && !isReverse ? ui.space(gap) : undefined,
 			},
-			/**
-			 * Improves stability of width/height rendering.
-			 * https://github.com/ItsJonQ/g2/pull/149
-			 */
-			'> *': {
-				minWidth: !isColumn ? 0 : null,
-				minHeight: isColumn ? 0 : null,
+		});
+
+		sx.WrapItems = css({
+			'> *:not(marquee)': {
+				marginBottom: ui.space(gap),
+				marginLeft: !isColumn && isReverse ? ui.space(gap) : undefined,
+				marginRight:
+					!isColumn && !isReverse ? ui.space(gap) : undefined,
+			},
+			'> *:last-child:not(marquee)': {
+				marginLeft: !isColumn && isReverse ? 0 : undefined,
+				marginRight: !isColumn && !isReverse ? 0 : undefined,
 			},
 		});
 
-		return cx(styles.Flex, sx.Base, className);
+		return cx(
+			styles.Flex,
+			sx.Base,
+			wrap ? sx.WrapItems : sx.Items,
+			isColumn ? styles.ItemsColumn : styles.ItemsRow,
+			className,
+		);
 	}, [
 		align,
 		alignItems,

--- a/packages/components/src/__tests__/__snapshots__/Components.test.js.snap
+++ b/packages/components/src/__tests__/__snapshots__/Components.test.js.snap
@@ -15511,20 +15511,35 @@ exports[`props should render FontSizeControl 1`] = `
   font-weight: normal;
   font-weight: var(--wp-g2-font-weight);
   margin: 0;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
-  display: -ms-grid;
-  display: grid;
-  gap: calc(4px * 3);
-  gap: calc(var(--wp-g2-grid-base) * 3);
-  -ms-grid-columns: minmax(0,1fr) minmax(auto,140px);
-  grid-template-columns: minmax(0,1fr) minmax(auto,140px);
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  --wp-g2-flex-gap: calc(4px * 2);
+  --wp-g2-flex-gap: calc(var(--wp-g2-grid-base) * 2);
+  --wp-g2-flex-item-margin-bottom: 0;
+  --wp-g2-flex-item-margin-right: calc(4px * 2);
+  --wp-g2-flex-item-margin-right: var(--wp-g2-flex-gap);
+  --wp-g2-flex-item-margin-left: 0;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  width: 100%;
+  margin-bottom: calc(calc(4px * 2) * -1);
+  margin-bottom: calc(calc(var(--wp-g2-grid-base) * 2) * -1);
+  --wp-g2-h-stack-spacing: calc(4px * 2);
+  --wp-g2-h-stack-spacing: calc(var(--wp-g2-grid-base) * 2);
 }
 
 @media (prefers-reduced-motion) {
@@ -15539,6 +15554,21 @@ exports[`props should render FontSizeControl 1`] = `
   transition: none!important;
 }
 
+.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2>*:not(marquee) {
+  margin-bottom: calc(4px * 2);
+  margin-bottom: calc(var(--wp-g2-grid-base) * 2);
+  margin-right: calc(4px * 2);
+  margin-right: calc(var(--wp-g2-grid-base) * 2);
+}
+
+.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2>*:last-child:not(marquee) {
+  margin-right: 0;
+}
+
+.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2>* {
+  min-width: 0;
+}
+
 .emotion-3.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3 {
   box-sizing: border-box;
   -moz-osx-font-smoothing: grayscale;
@@ -15550,20 +15580,8 @@ exports[`props should render FontSizeControl 1`] = `
   font-weight: normal;
   font-weight: var(--wp-g2-font-weight);
   margin: 0;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
-  display: -ms-grid;
-  display: grid;
-  gap: calc(4px * 3);
-  gap: calc(var(--wp-g2-grid-base) * 3);
-  -ms-grid-columns: 1fr 1fr;
-  grid-template-columns: 1fr 1fr;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
+  width: calc(100% * 0.25 - (calc(4px * 2) * 2));
+  width: calc(100% * 0.25 - (calc(var(--wp-g2-grid-base) * 2) * 2));
 }
 
 @media (prefers-reduced-motion) {
@@ -16054,6 +16072,10 @@ exports[`props should render FontSizeControl 1`] = `
   font-weight: normal;
   font-weight: var(--wp-g2-font-weight);
   margin: 0;
+  -webkit-align-self: flex-end;
+  -ms-flex-item-align: end;
+  align-self: flex-end;
+  min-width: calc(100% * 0.25);
 }
 
 @media (prefers-reduced-motion) {
@@ -16375,14 +16397,12 @@ exports[`props should render FontSizeControl 1`] = `
     data-g2-component="VStack"
   >
     <div
-      class="components-grid wp-components-grid emotion-2"
+      class="components-flex wp-components-flex components-h-stack wp-components-h-stack emotion-2"
       data-g2-c16t="true"
-      data-g2-component="Grid"
+      data-g2-component="HStack"
     >
       <div
-        class="components-grid wp-components-grid emotion-3"
-        data-g2-c16t="true"
-        data-g2-component="Grid"
+        class="emotion-3"
       >
         <div
           class="components-form-group wp-components-form-group emotion-4"
@@ -16468,34 +16488,34 @@ exports[`props should render FontSizeControl 1`] = `
             </div>
           </div>
         </div>
-        <div
-          class="emotion-12"
+      </div>
+      <div
+        class="emotion-12"
+      >
+        <button
+          aria-busy="false"
+          class="components-flex wp-components-flex components-base-button wp-components-base-button components-button wp-components-button emotion-13"
+          data-active="false"
+          data-destructive="false"
+          data-focused="false"
+          data-g2-c16t="true"
+          data-g2-component="Button"
+          data-icon="false"
+          disabled=""
         >
-          <button
-            aria-busy="false"
-            class="components-flex wp-components-flex components-base-button wp-components-base-button components-button wp-components-button emotion-13"
-            data-active="false"
-            data-destructive="false"
-            data-focused="false"
+          <span
+            class="components-flex-item wp-components-flex-item emotion-14"
             data-g2-c16t="true"
-            data-g2-component="Button"
-            data-icon="false"
-            disabled=""
+            data-g2-component="ButtonContent"
           >
-            <span
-              class="components-flex-item wp-components-flex-item emotion-14"
-              data-g2-c16t="true"
-              data-g2-component="ButtonContent"
-            >
-              Reset
-            </span>
-            <span
-              class="components-elevation wp-components-elevation emotion-15"
-              data-g2-c16t="true"
-              data-g2-component="ButtonElevation"
-            />
-          </button>
-        </div>
+            Reset
+          </span>
+          <span
+            class="components-elevation wp-components-elevation emotion-15"
+            data-g2-c16t="true"
+            data-g2-component="ButtonElevation"
+          />
+        </button>
       </div>
     </div>
   </div>
@@ -16603,20 +16623,35 @@ exports[`props should render FontSizeControl with css prop 1`] = `
   font-weight: normal;
   font-weight: var(--wp-g2-font-weight);
   margin: 0;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
-  display: -ms-grid;
-  display: grid;
-  gap: calc(4px * 3);
-  gap: calc(var(--wp-g2-grid-base) * 3);
-  -ms-grid-columns: minmax(0,1fr) minmax(auto,140px);
-  grid-template-columns: minmax(0,1fr) minmax(auto,140px);
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  --wp-g2-flex-gap: calc(4px * 2);
+  --wp-g2-flex-gap: calc(var(--wp-g2-grid-base) * 2);
+  --wp-g2-flex-item-margin-bottom: 0;
+  --wp-g2-flex-item-margin-right: calc(4px * 2);
+  --wp-g2-flex-item-margin-right: var(--wp-g2-flex-gap);
+  --wp-g2-flex-item-margin-left: 0;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  width: 100%;
+  margin-bottom: calc(calc(4px * 2) * -1);
+  margin-bottom: calc(calc(var(--wp-g2-grid-base) * 2) * -1);
+  --wp-g2-h-stack-spacing: calc(4px * 2);
+  --wp-g2-h-stack-spacing: calc(var(--wp-g2-grid-base) * 2);
 }
 
 @media (prefers-reduced-motion) {
@@ -16631,6 +16666,21 @@ exports[`props should render FontSizeControl with css prop 1`] = `
   transition: none!important;
 }
 
+.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2>*:not(marquee) {
+  margin-bottom: calc(4px * 2);
+  margin-bottom: calc(var(--wp-g2-grid-base) * 2);
+  margin-right: calc(4px * 2);
+  margin-right: calc(var(--wp-g2-grid-base) * 2);
+}
+
+.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2>*:last-child:not(marquee) {
+  margin-right: 0;
+}
+
+.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2>* {
+  min-width: 0;
+}
+
 .emotion-3.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3 {
   box-sizing: border-box;
   -moz-osx-font-smoothing: grayscale;
@@ -16642,20 +16692,8 @@ exports[`props should render FontSizeControl with css prop 1`] = `
   font-weight: normal;
   font-weight: var(--wp-g2-font-weight);
   margin: 0;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
-  display: -ms-grid;
-  display: grid;
-  gap: calc(4px * 3);
-  gap: calc(var(--wp-g2-grid-base) * 3);
-  -ms-grid-columns: 1fr 1fr;
-  grid-template-columns: 1fr 1fr;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
+  width: calc(100% * 0.25 - (calc(4px * 2) * 2));
+  width: calc(100% * 0.25 - (calc(var(--wp-g2-grid-base) * 2) * 2));
 }
 
 @media (prefers-reduced-motion) {
@@ -17146,6 +17184,10 @@ exports[`props should render FontSizeControl with css prop 1`] = `
   font-weight: normal;
   font-weight: var(--wp-g2-font-weight);
   margin: 0;
+  -webkit-align-self: flex-end;
+  -ms-flex-item-align: end;
+  align-self: flex-end;
+  min-width: calc(100% * 0.25);
 }
 
 @media (prefers-reduced-motion) {
@@ -17467,14 +17509,12 @@ exports[`props should render FontSizeControl with css prop 1`] = `
     data-g2-component="VStack"
   >
     <div
-      class="components-grid wp-components-grid emotion-2"
+      class="components-flex wp-components-flex components-h-stack wp-components-h-stack emotion-2"
       data-g2-c16t="true"
-      data-g2-component="Grid"
+      data-g2-component="HStack"
     >
       <div
-        class="components-grid wp-components-grid emotion-3"
-        data-g2-c16t="true"
-        data-g2-component="Grid"
+        class="emotion-3"
       >
         <div
           class="components-form-group wp-components-form-group emotion-4"
@@ -17560,34 +17600,34 @@ exports[`props should render FontSizeControl with css prop 1`] = `
             </div>
           </div>
         </div>
-        <div
-          class="emotion-12"
+      </div>
+      <div
+        class="emotion-12"
+      >
+        <button
+          aria-busy="false"
+          class="components-flex wp-components-flex components-base-button wp-components-base-button components-button wp-components-button emotion-13"
+          data-active="false"
+          data-destructive="false"
+          data-focused="false"
+          data-g2-c16t="true"
+          data-g2-component="Button"
+          data-icon="false"
+          disabled=""
         >
-          <button
-            aria-busy="false"
-            class="components-flex wp-components-flex components-base-button wp-components-base-button components-button wp-components-button emotion-13"
-            data-active="false"
-            data-destructive="false"
-            data-focused="false"
+          <span
+            class="components-flex-item wp-components-flex-item emotion-14"
             data-g2-c16t="true"
-            data-g2-component="Button"
-            data-icon="false"
-            disabled=""
+            data-g2-component="ButtonContent"
           >
-            <span
-              class="components-flex-item wp-components-flex-item emotion-14"
-              data-g2-c16t="true"
-              data-g2-component="ButtonContent"
-            >
-              Reset
-            </span>
-            <span
-              class="components-elevation wp-components-elevation emotion-15"
-              data-g2-c16t="true"
-              data-g2-component="ButtonElevation"
-            />
-          </button>
-        </div>
+            Reset
+          </span>
+          <span
+            class="components-elevation wp-components-elevation emotion-15"
+            data-g2-c16t="true"
+            data-g2-component="ButtonElevation"
+          />
+        </button>
       </div>
     </div>
   </div>
@@ -17697,20 +17737,35 @@ exports[`props should render FontSizeControl with css prop 2`] = `
   font-weight: normal;
   font-weight: var(--wp-g2-font-weight);
   margin: 0;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
-  display: -ms-grid;
-  display: grid;
-  gap: calc(4px * 3);
-  gap: calc(var(--wp-g2-grid-base) * 3);
-  -ms-grid-columns: minmax(0,1fr) minmax(auto,140px);
-  grid-template-columns: minmax(0,1fr) minmax(auto,140px);
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  --wp-g2-flex-gap: calc(4px * 2);
+  --wp-g2-flex-gap: calc(var(--wp-g2-grid-base) * 2);
+  --wp-g2-flex-item-margin-bottom: 0;
+  --wp-g2-flex-item-margin-right: calc(4px * 2);
+  --wp-g2-flex-item-margin-right: var(--wp-g2-flex-gap);
+  --wp-g2-flex-item-margin-left: 0;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  width: 100%;
+  margin-bottom: calc(calc(4px * 2) * -1);
+  margin-bottom: calc(calc(var(--wp-g2-grid-base) * 2) * -1);
+  --wp-g2-h-stack-spacing: calc(4px * 2);
+  --wp-g2-h-stack-spacing: calc(var(--wp-g2-grid-base) * 2);
 }
 
 @media (prefers-reduced-motion) {
@@ -17725,6 +17780,21 @@ exports[`props should render FontSizeControl with css prop 2`] = `
   transition: none!important;
 }
 
+.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2>*:not(marquee) {
+  margin-bottom: calc(4px * 2);
+  margin-bottom: calc(var(--wp-g2-grid-base) * 2);
+  margin-right: calc(4px * 2);
+  margin-right: calc(var(--wp-g2-grid-base) * 2);
+}
+
+.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2>*:last-child:not(marquee) {
+  margin-right: 0;
+}
+
+.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2.emotion-2>* {
+  min-width: 0;
+}
+
 .emotion-3.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3.emotion-3 {
   box-sizing: border-box;
   -moz-osx-font-smoothing: grayscale;
@@ -17736,20 +17806,8 @@ exports[`props should render FontSizeControl with css prop 2`] = `
   font-weight: normal;
   font-weight: var(--wp-g2-font-weight);
   margin: 0;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
-  display: -ms-grid;
-  display: grid;
-  gap: calc(4px * 3);
-  gap: calc(var(--wp-g2-grid-base) * 3);
-  -ms-grid-columns: 1fr 1fr;
-  grid-template-columns: 1fr 1fr;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
+  width: calc(100% * 0.25 - (calc(4px * 2) * 2));
+  width: calc(100% * 0.25 - (calc(var(--wp-g2-grid-base) * 2) * 2));
 }
 
 @media (prefers-reduced-motion) {
@@ -18240,6 +18298,10 @@ exports[`props should render FontSizeControl with css prop 2`] = `
   font-weight: normal;
   font-weight: var(--wp-g2-font-weight);
   margin: 0;
+  -webkit-align-self: flex-end;
+  -ms-flex-item-align: end;
+  align-self: flex-end;
+  min-width: calc(100% * 0.25);
 }
 
 @media (prefers-reduced-motion) {
@@ -18561,14 +18623,12 @@ exports[`props should render FontSizeControl with css prop 2`] = `
     data-g2-component="VStack"
   >
     <div
-      class="components-grid wp-components-grid emotion-2"
+      class="components-flex wp-components-flex components-h-stack wp-components-h-stack emotion-2"
       data-g2-c16t="true"
-      data-g2-component="Grid"
+      data-g2-component="HStack"
     >
       <div
-        class="components-grid wp-components-grid emotion-3"
-        data-g2-c16t="true"
-        data-g2-component="Grid"
+        class="emotion-3"
       >
         <div
           class="components-form-group wp-components-form-group emotion-4"
@@ -18654,34 +18714,34 @@ exports[`props should render FontSizeControl with css prop 2`] = `
             </div>
           </div>
         </div>
-        <div
-          class="emotion-12"
+      </div>
+      <div
+        class="emotion-12"
+      >
+        <button
+          aria-busy="false"
+          class="components-flex wp-components-flex components-base-button wp-components-base-button components-button wp-components-button emotion-13"
+          data-active="false"
+          data-destructive="false"
+          data-focused="false"
+          data-g2-c16t="true"
+          data-g2-component="Button"
+          data-icon="false"
+          disabled=""
         >
-          <button
-            aria-busy="false"
-            class="components-flex wp-components-flex components-base-button wp-components-base-button components-button wp-components-button emotion-13"
-            data-active="false"
-            data-destructive="false"
-            data-focused="false"
+          <span
+            class="components-flex-item wp-components-flex-item emotion-14"
             data-g2-c16t="true"
-            data-g2-component="Button"
-            data-icon="false"
-            disabled=""
+            data-g2-component="ButtonContent"
           >
-            <span
-              class="components-flex-item wp-components-flex-item emotion-14"
-              data-g2-c16t="true"
-              data-g2-component="ButtonContent"
-            >
-              Reset
-            </span>
-            <span
-              class="components-elevation wp-components-elevation emotion-15"
-              data-g2-c16t="true"
-              data-g2-component="ButtonElevation"
-            />
-          </button>
-        </div>
+            Reset
+          </span>
+          <span
+            class="components-elevation wp-components-elevation emotion-15"
+            data-g2-c16t="true"
+            data-g2-component="ButtonElevation"
+          />
+        </button>
       </div>
     </div>
   </div>

--- a/packages/components/src/font-size-control/font-size-control-select.js
+++ b/packages/components/src/font-size-control/font-size-control-select.js
@@ -1,15 +1,16 @@
 import { __ } from '@wordpress/i18n';
 import { contextConnect, useContextSystem } from '@wp-g2/context';
+import { ui } from '@wp-g2/styles';
 import { noop } from '@wp-g2/utils';
 import React from 'react';
 
 import { Button } from '../Button';
 import { FormGroup } from '../FormGroup';
-import { Grid } from '../Grid';
+import { HStack } from '../HStack';
 import { SelectDropdown } from '../select-dropdown';
 import { TextInput } from '../TextInput';
 import { View } from '../View';
-import { getSelectTemplateColumns } from './font-size-control-utils';
+import * as styles from './font-size-control-styles';
 
 function FontSizeControlSelect(props, forwardedRef) {
 	const {
@@ -31,36 +32,32 @@ function FontSizeControlSelect(props, forwardedRef) {
 		...otherProps
 	} = useContextSystem(props, 'FontSizeControlSelect');
 
-	const templateColumns = getSelectTemplateColumns(withNumberInput);
-	const subControlsTemplateColumns = withNumberInput ? '1fr 1fr' : '1fr';
-
 	const renderItem = React.useCallback(
 		({ name, style }) => <span style={style}>{name}</span>,
 		[],
 	);
 
 	return (
-		<Grid alignment="bottom" templateColumns={templateColumns}>
+		<HStack alignment="left" wrap>
 			{withSelect && (
-				<FormGroup label={label}>
-					<SelectDropdown
-						disabled={disabled}
-						max={260}
-						onChange={onChange}
-						options={options}
-						ref={forwardedRef}
-						renderItem={renderItem}
-						size={size}
-						value={value}
-						{...otherProps}
-					/>
-				</FormGroup>
+				<View className={styles.SelectDropdownWrapper}>
+					<FormGroup label={label}>
+						<SelectDropdown
+							disabled={disabled}
+							max={260}
+							onChange={onChange}
+							options={options}
+							ref={forwardedRef}
+							renderItem={renderItem}
+							size={size}
+							value={value}
+							{...otherProps}
+						/>
+					</FormGroup>
+				</View>
 			)}
-			<Grid
-				alignment="bottom"
-				templateColumns={subControlsTemplateColumns}
-			>
-				{withNumberInput && (
+			{withNumberInput && (
+				<View className={styles.NumberInputWrapper}>
 					<FormGroup label={customLabel}>
 						<TextInput
 							disabled={disabled}
@@ -72,14 +69,14 @@ function FontSizeControlSelect(props, forwardedRef) {
 							value={inputValue}
 						/>
 					</FormGroup>
-				)}
-				<View>
-					<Button disabled={isDefaultValue} isBlock onClick={onReset}>
-						{__('Reset')}
-					</Button>
 				</View>
-			</Grid>
-		</Grid>
+			)}
+			<View className={styles.ResetButtonWrapper}>
+				<Button disabled={isDefaultValue} isBlock onClick={onReset}>
+					{__('Reset')}
+				</Button>
+			</View>
+		</HStack>
 	);
 }
 

--- a/packages/components/src/font-size-control/font-size-control-slider.js
+++ b/packages/components/src/font-size-control/font-size-control-slider.js
@@ -3,11 +3,12 @@ import { noop } from '@wp-g2/utils';
 import React from 'react';
 
 import { ControlLabel } from '../ControlLabel';
-import { Grid } from '../Grid';
+import { HStack } from '../HStack';
 import { Slider } from '../Slider';
 import { TextInput } from '../TextInput';
+import { View } from '../View';
 import { VStack } from '../VStack';
-import { getSliderTemplateColumns } from './font-size-control-utils';
+import * as styles from './font-size-control-styles';
 
 function FontSizeControlSlider(props) {
 	const {
@@ -23,8 +24,6 @@ function FontSizeControlSlider(props) {
 
 	if (!withSlider) return null;
 
-	const templateColumns = getSliderTemplateColumns();
-
 	const controlProps = {
 		disabled,
 		min,
@@ -37,10 +36,14 @@ function FontSizeControlSlider(props) {
 	return (
 		<VStack spacing={0}>
 			<ControlLabel>{label}</ControlLabel>
-			<Grid templateColumns={templateColumns}>
-				<Slider {...controlProps} />
-				<TextInput {...controlProps} type="number" />
-			</Grid>
+			<HStack wrap>
+				<View className={styles.SliderWrapper}>
+					<Slider {...controlProps} />
+				</View>
+				<View>
+					<TextInput {...controlProps} type="number" />
+				</View>
+			</HStack>
 		</VStack>
 	);
 }

--- a/packages/components/src/font-size-control/font-size-control-styles.js
+++ b/packages/components/src/font-size-control/font-size-control-styles.js
@@ -1,8 +1,25 @@
-import { css } from '@wp-g2/styles';
+import { css, ui } from '@wp-g2/styles';
 
 export const FontSizeControl = css`
 	appearance: none;
 	border: none;
 	margin: 0;
 	padding: 0;
+`;
+
+export const SelectDropdownWrapper = css`
+	width: calc(100% * 0.5 - (${ui.space(2)} * 2));
+`;
+
+export const NumberInputWrapper = css`
+	width: calc(100% * 0.25 - (${ui.space(2)} * 2));
+`;
+
+export const ResetButtonWrapper = css`
+	align-self: flex-end;
+	min-width: calc(100% * 0.25);
+`;
+
+export const SliderWrapper = css`
+	width: calc(100% * 0.75);
 `;

--- a/packages/components/src/font-size-control/font-size-control-utils.js
+++ b/packages/components/src/font-size-control/font-size-control-utils.js
@@ -1,11 +1,9 @@
 import { __ } from '@wordpress/i18n';
-import { ui } from '@wp-g2/styles';
 import { createUnitValue, parseUnitValue } from '@wp-g2/utils';
 
 const DEFAULT_FONT_SIZE = 'default';
 const CUSTOM_FONT_SIZE = 'custom';
 const MAX_FONT_SIZE_DISPLAY = '25px';
-const ASIDE_CONTROL_WIDTH = 70;
 
 export function hasUnit(value) {
 	const [, unit] = parseUnitValue(value);
@@ -82,14 +80,4 @@ export function getInputValue(fontSizes = [], value) {
 	const inputValue = (isPixelValue && noUnitsValue) || '';
 
 	return inputValue;
-}
-
-export function getSelectTemplateColumns(withNumberInput) {
-	return withNumberInput
-		? `minmax(0, 1fr) minmax(auto, ${ui.value.px(ASIDE_CONTROL_WIDTH * 2)})`
-		: `minmax(0, 2fr) minmax(auto, ${ui.value.px(ASIDE_CONTROL_WIDTH)})`;
-}
-
-export function getSliderTemplateColumns() {
-	return `2fr minmax(auto, ${ui.value.px(ASIDE_CONTROL_WIDTH)})`;
 }


### PR DESCRIPTION
This update improves Flex-based layout rendering for potentially longer translation labels.

This is achieved by enhancing how `Flex` handles `wrap` rendering. Previously, `Flex` only provided margin gaps on one axis (either `x` for horizontal, or `y` for vertical). With the updated `<Flex wrap />`, the `gap` value is now applied on both `x` and `y` to accommodate wrapped content.

This solution seems to work well. However, it involves quite a bit of manual CSS for the individual children of `HStack`.

The `FontSizeControl` how uses `HStack` instead of `Grid` for inner UI rendering. 

<img width="553" alt="Screen Shot 2021-02-01 at 11 15 51 AM" src="https://user-images.githubusercontent.com/2322354/106486442-a6faa380-647f-11eb-9825-9dd94f73a529.png">
(Screenshot of Google translated German labels)


<img width="579" alt="Screen Shot 2021-02-01 at 11 21 47 AM" src="https://user-images.githubusercontent.com/2322354/106486480-b11ca200-647f-11eb-96f8-e1e09e7f1707.png">
(Original English labels)

---

### FontSizeControl

The changes made to this `FontSizeControl` need to be ported to Gutenberg.
We technically don't need to update `FontSizeControl` here. I mostly did it for reference to make the updating easier in Gutenberg.

---

Resolves https://github.com/ItsJonQ/g2/issues/251