### PR TITLE
Remove need for memoization in accordion

### DIFF
--- a/packages/components/src/Accordion/Accordion.Context.js
+++ b/packages/components/src/Accordion/Accordion.Context.js
@@ -18,9 +18,7 @@ export const AccordionContext = createContext({
 	allowMultiple: false,
 	current: [],
 	getIsVisible: noop,
-	add: noop,
-	set: noop,
-	remove: noop,
+	dispatch: noop,
 });
 
 export const useAccordionContext = () => useContext(AccordionContext);

--- a/packages/components/src/Accordion/useAccordion.js
+++ b/packages/components/src/Accordion/useAccordion.js
@@ -49,15 +49,6 @@ function useInitialState({ allowMultiple = false, current }) {
 	return initialState;
 }
 
-/**
- * @template {(...args: any[]) => any} T
- * @param {T} fn
- * @returns {T}
- */
-function useAction(fn) {
-	return useCallback(fn, []);
-}
-
 /** @typedef {string | string[]} Payload */
 
 /** @typedef {{ type: 'add', payload: Payload }} AddAction */
@@ -71,6 +62,8 @@ function useAction(fn) {
 	| SetAction
 } Action
  */
+
+/** @typedef {import('react').Dispatch<Action>} AccordionDispatch */
 
 /**
  * @param {State} state
@@ -119,6 +112,35 @@ function reducer(state, action) {
 }
 
 /**
+ * @param {AccordionDispatch} dispatch
+ * @param {Payload} payload
+ */
+export function add(dispatch, payload) {
+	dispatch({ type: 'add', payload });
+}
+
+/**
+ * @param {AccordionDispatch} dispatch
+ * @param {Payload} payload
+ */
+export function remove(dispatch, payload) {
+	dispatch({ type: 'remove', payload });
+}
+
+/**
+ * @param {AccordionDispatch} dispatch
+ * @param {Payload} payload
+ * @param {boolean} allowMultiple
+ */
+export function set(dispatch, payload, allowMultiple) {
+	if (allowMultiple) {
+		add(dispatch, payload);
+	} else {
+		dispatch({ type: 'set', payload });
+	}
+}
+
+/**
  * @typedef {State & { onChange: (current: State['current']) => void }} OwnProps
  */
 
@@ -139,27 +161,14 @@ export function useAccordionState(props) {
 		initialState,
 	);
 
-	// Actions
-	const add = useAction((/** @type {Payload} */ next) => {
-		dispatch({ type: 'add', payload: next });
-	});
-	const remove = useAction((/** @type {Payload} */ next) => {
-		dispatch({ type: 'remove', payload: next });
-	});
-	const set = useAction((/** @type {Payload} */ next) => {
-		if (allowMultiple) return add(next);
-
-		dispatch({ type: 'set', payload: next });
-	});
-
 	// Selectors
 	const getIsVisible = (/** @type {string} */ id) =>
 		!!id && current?.includes(id);
 
 	// Synchronize props + state
 	useUpdateEffect(() => {
-		set(props.current);
-	}, [set, props.current]);
+		set(dispatch, props.current, allowMultiple);
+	}, [props.current]);
 
 	useUpdateEffect(() => {
 		onChange(current);
@@ -169,9 +178,7 @@ export function useAccordionState(props) {
 		allowMultiple,
 		current,
 		getIsVisible,
-		add,
-		remove,
-		set,
+		dispatch,
 	};
 }
 
@@ -208,13 +215,7 @@ export function useAccordionProps(props) {
  * @return {[boolean, (id: string) => boolean ]}
  */
 export function useAccordion({ id, visible: visibleProp }) {
-	const {
-		add,
-		allowMultiple,
-		getIsVisible,
-		remove,
-		set,
-	} = useAccordionContext();
+	const { allowMultiple, dispatch, getIsVisible } = useAccordionContext();
 
 	const visible = getIsVisible(id);
 
@@ -224,17 +225,17 @@ export function useAccordion({ id, visible: visibleProp }) {
 
 			if (nextVisible) {
 				if (allowMultiple) {
-					add(id);
+					add(dispatch, id);
 				} else {
-					set(id);
+					set(dispatch, id, allowMultiple);
 				}
 			} else {
 				if (allowMultiple) {
-					remove(id);
+					remove(dispatch, id);
 				}
 			}
 		},
-		[add, allowMultiple, remove, set, id],
+		[id, allowMultiple, dispatch],
 	);
 
 	useUpdateEffect(() => {


### PR DESCRIPTION
By moving action functions into module level functions we remove the need to memoize them. Their signature expands but not to the point of being unweildy.

Just an interesting approach to this problem, may or may not be something we adopt.

https://twitter.com/dan_abramov/status/1125774170154065920
