### PR TITLE
Text: Improve muted contrast ratio

### DIFF
--- a/packages/components/src/ControlGroup/__tests__/__snapshots__/ControlGroup.test.js.snap
+++ b/packages/components/src/ControlGroup/__tests__/__snapshots__/ControlGroup.test.js.snap
@@ -935,7 +935,7 @@ exports[`props should render mixed control types 1`] = `
   font-weight: normal;
   font-weight: var(--wp-g2-font-weight);
   display: block;
-  color: #8a8b8c;
+  color: #717171;
   color: var(--wp-g2-color-text-muted);
 }
 

--- a/packages/components/src/Select/__tests__/__snapshots__/Select.test.js.snap
+++ b/packages/components/src/Select/__tests__/__snapshots__/Select.test.js.snap
@@ -269,7 +269,7 @@ exports[`props should render children 1`] = `
   font-weight: normal;
   font-weight: var(--wp-g2-font-weight);
   display: block;
-  color: #8a8b8c;
+  color: #717171;
   color: var(--wp-g2-color-text-muted);
 }
 
@@ -648,7 +648,7 @@ exports[`props should render correctly 1`] = `
   font-weight: normal;
   font-weight: var(--wp-g2-font-weight);
   display: block;
-  color: #8a8b8c;
+  color: #717171;
   color: var(--wp-g2-color-text-muted);
 }
 
@@ -1028,7 +1028,7 @@ exports[`props should render disabled 1`] = `
   font-weight: normal;
   font-weight: var(--wp-g2-font-weight);
   display: block;
-  color: #8a8b8c;
+  color: #717171;
   color: var(--wp-g2-color-text-muted);
 }
 
@@ -1410,7 +1410,7 @@ exports[`props should render readOnly 1`] = `
   font-weight: normal;
   font-weight: var(--wp-g2-font-weight);
   display: block;
-  color: #8a8b8c;
+  color: #717171;
   color: var(--wp-g2-color-text-muted);
 }
 
@@ -1791,7 +1791,7 @@ exports[`props should render required 1`] = `
   font-weight: normal;
   font-weight: var(--wp-g2-font-weight);
   display: block;
-  color: #8a8b8c;
+  color: #717171;
   color: var(--wp-g2-color-text-muted);
 }
 
@@ -2178,7 +2178,7 @@ exports[`props should render size 1`] = `
   font-weight: normal;
   font-weight: var(--wp-g2-font-weight);
   display: block;
-  color: #8a8b8c;
+  color: #717171;
   color: var(--wp-g2-color-text-muted);
 }
 

--- a/packages/components/src/Slider/__tests__/__snapshots__/Slider.test.js.snap
+++ b/packages/components/src/Slider/__tests__/__snapshots__/Slider.test.js.snap
@@ -98,9 +98,9 @@ exports[`props should render correctly 1`] = `
 }
 
 *:disabled.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0::-webkit-slider-thumb {
-  background: #8a8b8c;
+  background: #717171;
   background: var(--wp-g2-color-text-muted);
-  border-color: #8a8b8c;
+  border-color: #717171;
   border-color: var(--wp-g2-color-text-muted);
 }
 
@@ -128,9 +128,9 @@ exports[`props should render correctly 1`] = `
 }
 
 *:disabled.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0::-moz-range-thumb {
-  background: #8a8b8c;
+  background: #717171;
   background: var(--wp-g2-color-text-muted);
-  border-color: #8a8b8c;
+  border-color: #717171;
   border-color: var(--wp-g2-color-text-muted);
 }
 
@@ -255,9 +255,9 @@ exports[`props should render max 1`] = `
 }
 
 *:disabled.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0::-webkit-slider-thumb {
-  background: #8a8b8c;
+  background: #717171;
   background: var(--wp-g2-color-text-muted);
-  border-color: #8a8b8c;
+  border-color: #717171;
   border-color: var(--wp-g2-color-text-muted);
 }
 
@@ -285,9 +285,9 @@ exports[`props should render max 1`] = `
 }
 
 *:disabled.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0::-moz-range-thumb {
-  background: #8a8b8c;
+  background: #717171;
   background: var(--wp-g2-color-text-muted);
-  border-color: #8a8b8c;
+  border-color: #717171;
   border-color: var(--wp-g2-color-text-muted);
 }
 
@@ -412,9 +412,9 @@ exports[`props should render min 1`] = `
 }
 
 *:disabled.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0::-webkit-slider-thumb {
-  background: #8a8b8c;
+  background: #717171;
   background: var(--wp-g2-color-text-muted);
-  border-color: #8a8b8c;
+  border-color: #717171;
   border-color: var(--wp-g2-color-text-muted);
 }
 
@@ -442,9 +442,9 @@ exports[`props should render min 1`] = `
 }
 
 *:disabled.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0::-moz-range-thumb {
-  background: #8a8b8c;
+  background: #717171;
   background: var(--wp-g2-color-text-muted);
-  border-color: #8a8b8c;
+  border-color: #717171;
   border-color: var(--wp-g2-color-text-muted);
 }
 
@@ -571,9 +571,9 @@ exports[`props should render size 1`] = `
 }
 
 *:disabled.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0::-webkit-slider-thumb {
-  background: #8a8b8c;
+  background: #717171;
   background: var(--wp-g2-color-text-muted);
-  border-color: #8a8b8c;
+  border-color: #717171;
   border-color: var(--wp-g2-color-text-muted);
 }
 
@@ -601,9 +601,9 @@ exports[`props should render size 1`] = `
 }
 
 *:disabled.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0::-moz-range-thumb {
-  background: #8a8b8c;
+  background: #717171;
   background: var(--wp-g2-color-text-muted);
-  border-color: #8a8b8c;
+  border-color: #717171;
   border-color: var(--wp-g2-color-text-muted);
 }
 
@@ -728,9 +728,9 @@ exports[`props should render unit value 1`] = `
 }
 
 *:disabled.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0::-webkit-slider-thumb {
-  background: #8a8b8c;
+  background: #717171;
   background: var(--wp-g2-color-text-muted);
-  border-color: #8a8b8c;
+  border-color: #717171;
   border-color: var(--wp-g2-color-text-muted);
 }
 
@@ -758,9 +758,9 @@ exports[`props should render unit value 1`] = `
 }
 
 *:disabled.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0::-moz-range-thumb {
-  background: #8a8b8c;
+  background: #717171;
   background: var(--wp-g2-color-text-muted);
-  border-color: #8a8b8c;
+  border-color: #717171;
   border-color: var(--wp-g2-color-text-muted);
 }
 
@@ -885,9 +885,9 @@ exports[`props should render value 1`] = `
 }
 
 *:disabled.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0::-webkit-slider-thumb {
-  background: #8a8b8c;
+  background: #717171;
   background: var(--wp-g2-color-text-muted);
-  border-color: #8a8b8c;
+  border-color: #717171;
   border-color: var(--wp-g2-color-text-muted);
 }
 
@@ -915,9 +915,9 @@ exports[`props should render value 1`] = `
 }
 
 *:disabled.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0::-moz-range-thumb {
-  background: #8a8b8c;
+  background: #717171;
   background: var(--wp-g2-color-text-muted);
-  border-color: #8a8b8c;
+  border-color: #717171;
   border-color: var(--wp-g2-color-text-muted);
 }
 

--- a/packages/components/src/Subheading/__tests__/__snapshots__/Subheading.test.js.snap
+++ b/packages/components/src/Subheading/__tests__/__snapshots__/Subheading.test.js.snap
@@ -20,7 +20,7 @@ exports[`props should render correctly 1`] = `
   font-size: calc(0.7692307692307693 * var(--wp-g2-font-size));
   font-weight: 600;
   display: block;
-  color: #8a8b8c;
+  color: #717171;
   color: var(--wp-g2-color-text-muted);
   text-transform: uppercase;
 }

--- a/packages/components/src/Text/__tests__/__snapshots__/Text.test.js.snap
+++ b/packages/components/src/Text/__tests__/__snapshots__/Text.test.js.snap
@@ -716,7 +716,7 @@ exports[`props should render variant 1`] = `
   font-size: calc(1 * var(--wp-g2-font-size));
   font-weight: normal;
   font-weight: var(--wp-g2-font-weight);
-  color: #8a8b8c;
+  color: #717171;
   color: var(--wp-g2-color-text-muted);
 }
 

--- a/packages/components/src/__tests__/__snapshots__/Components.test.js.snap
+++ b/packages/components/src/__tests__/__snapshots__/Components.test.js.snap
@@ -27258,7 +27258,7 @@ exports[`props should render Select 1`] = `
   font-weight: normal;
   font-weight: var(--wp-g2-font-weight);
   display: block;
-  color: #8a8b8c;
+  color: #717171;
   color: var(--wp-g2-color-text-muted);
 }
 
@@ -27682,7 +27682,7 @@ exports[`props should render SelectDropdown 1`] = `
   font-weight: normal;
   font-weight: var(--wp-g2-font-weight);
   display: block;
-  color: #8a8b8c;
+  color: #717171;
   color: var(--wp-g2-color-text-muted);
 }
 
@@ -28159,7 +28159,7 @@ exports[`props should render SelectDropdown with css prop 1`] = `
   font-weight: normal;
   font-weight: var(--wp-g2-font-weight);
   display: block;
-  color: #8a8b8c;
+  color: #717171;
   color: var(--wp-g2-color-text-muted);
 }
 
@@ -28638,7 +28638,7 @@ exports[`props should render SelectDropdown with css prop 2`] = `
   font-weight: normal;
   font-weight: var(--wp-g2-font-weight);
   display: block;
-  color: #8a8b8c;
+  color: #717171;
   color: var(--wp-g2-color-text-muted);
 }
 
@@ -28963,9 +28963,9 @@ exports[`props should render Slider 1`] = `
 }
 
 *:disabled.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0::-webkit-slider-thumb {
-  background: #8a8b8c;
+  background: #717171;
   background: var(--wp-g2-color-text-muted);
-  border-color: #8a8b8c;
+  border-color: #717171;
   border-color: var(--wp-g2-color-text-muted);
 }
 
@@ -28993,9 +28993,9 @@ exports[`props should render Slider 1`] = `
 }
 
 *:disabled.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0::-moz-range-thumb {
-  background: #8a8b8c;
+  background: #717171;
   background: var(--wp-g2-color-text-muted);
-  border-color: #8a8b8c;
+  border-color: #717171;
   border-color: var(--wp-g2-color-text-muted);
 }
 
@@ -29120,9 +29120,9 @@ exports[`props should render Slider with css prop 1`] = `
 }
 
 *:disabled.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0::-webkit-slider-thumb {
-  background: #8a8b8c;
+  background: #717171;
   background: var(--wp-g2-color-text-muted);
-  border-color: #8a8b8c;
+  border-color: #717171;
   border-color: var(--wp-g2-color-text-muted);
 }
 
@@ -29150,9 +29150,9 @@ exports[`props should render Slider with css prop 1`] = `
 }
 
 *:disabled.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0::-moz-range-thumb {
-  background: #8a8b8c;
+  background: #717171;
   background: var(--wp-g2-color-text-muted);
-  border-color: #8a8b8c;
+  border-color: #717171;
   border-color: var(--wp-g2-color-text-muted);
 }
 
@@ -29279,9 +29279,9 @@ exports[`props should render Slider with css prop 2`] = `
 }
 
 *:disabled.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0::-webkit-slider-thumb {
-  background: #8a8b8c;
+  background: #717171;
   background: var(--wp-g2-color-text-muted);
-  border-color: #8a8b8c;
+  border-color: #717171;
   border-color: var(--wp-g2-color-text-muted);
 }
 
@@ -29309,9 +29309,9 @@ exports[`props should render Slider with css prop 2`] = `
 }
 
 *:disabled.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0.emotion-0::-moz-range-thumb {
-  background: #8a8b8c;
+  background: #717171;
   background: var(--wp-g2-color-text-muted);
-  border-color: #8a8b8c;
+  border-color: #717171;
   border-color: var(--wp-g2-color-text-muted);
 }
 
@@ -32574,7 +32574,7 @@ exports[`props should render Subheading 1`] = `
   font-size: calc(0.7692307692307693 * var(--wp-g2-font-size));
   font-weight: 600;
   display: block;
-  color: #8a8b8c;
+  color: #717171;
   color: var(--wp-g2-color-text-muted);
   text-transform: uppercase;
 }
@@ -32619,7 +32619,7 @@ exports[`props should render Subheading with css prop 1`] = `
   font-size: calc(0.7692307692307693 * var(--wp-g2-font-size));
   font-weight: 600;
   display: block;
-  color: #8a8b8c;
+  color: #717171;
   color: var(--wp-g2-color-text-muted);
   text-transform: uppercase;
 }
@@ -32664,7 +32664,7 @@ exports[`props should render Subheading with css prop 2`] = `
   font-size: calc(0.7692307692307693 * var(--wp-g2-font-size));
   font-weight: 600;
   display: block;
-  color: #8a8b8c;
+  color: #717171;
   color: var(--wp-g2-color-text-muted);
   text-transform: uppercase;
   background: red;

--- a/packages/components/src/select-dropdown/__tests__/__snapshots__/index.js.snap
+++ b/packages/components/src/select-dropdown/__tests__/__snapshots__/index.js.snap
@@ -324,7 +324,7 @@ exports[`props should render correctly 1`] = `
   font-weight: normal;
   font-weight: var(--wp-g2-font-weight);
   display: block;
-  color: #8a8b8c;
+  color: #717171;
   color: var(--wp-g2-color-text-muted);
 }
 

--- a/packages/styles/src/theme/config.js
+++ b/packages/styles/src/theme/config.js
@@ -42,7 +42,7 @@ const COLOR_PROPS = {
 	colorText: '#1e1e1e',
 	colorTextInverted: get('white'),
 	colorTextHeading: '#050505',
-	colorTextMuted: '#8a8b8c',
+	colorTextMuted: '#717171',
 	...generateColorAdminColors('#007cba'),
 	...generateColorDestructiveColors('#D94F4F'),
 };

--- a/packages/styles/src/theme/dark-mode-config.js
+++ b/packages/styles/src/theme/dark-mode-config.js
@@ -13,6 +13,7 @@ const DARK_MODE_PROPS = {
 	colorScrollbarThumbHover: 'rgba(255, 255, 255, 0.5)',
 	colorScrollbarTrack: 'rgba(0, 0, 0, 0.04)',
 	colorText: '#E4E6EB',
+	colorTextMuted: '#7a7a7a',
 	colorTextInverted: '#050505',
 	colorTextHeading: '#ffffff',
 	controlBackgroundColor: get('colorBodyBackground'),


### PR DESCRIPTION
<img width="349" alt="Screen Shot 2021-02-11 at 11 19 11 AM" src="https://user-images.githubusercontent.com/2322354/107665461-72df6980-6c5b-11eb-9f11-c9153f6c361d.png">

This update improves the contrast ratio of the `muted` variant for `Text` based components.
The value has been updated for both light and dark modes.

Resolves https://github.com/ItsJonQ/g2/issues/260