### PR TITLE
SelectDropdown: Remove inline CSS comment

### DIFF
--- a/packages/components/src/select-dropdown/select-dropdown-styles.js
+++ b/packages/components/src/select-dropdown/select-dropdown-styles.js
@@ -11,7 +11,7 @@ export const Popover = css`
 	opacity: 1;
 	outline: none;
 	transition: 40ms opacity linear;
-	transition-delay: 20ms; // Allows for the popover to reposition without being seen.
+	transition-delay: 20ms;
 `;
 
 export const popoverHidden = css`


### PR DESCRIPTION
This update removes the inline (JS) comment within the CSS string for `SelectDropdown`.

Resolves https://github.com/ItsJonQ/g2/issues/266