### PR TITLE
RTL: Check document.dir on css() execution rather than using a cached value

### DIFF
--- a/packages/create-styles/src/create-compiler/__tests__/rtl.test.js
+++ b/packages/create-styles/src/create-compiler/__tests__/rtl.test.js
@@ -1,0 +1,19 @@
+import { getRtl } from '../plugins/rtl';
+
+describe('getRtl', () => {
+	afterEach(() => {
+		document.dir = '';
+	});
+
+	test('should return false when document has no dir setting', () => {
+		expect(getRtl()).toBe(false);
+	});
+
+	test('should return false when document is ltr', () => {
+		document.dir = 'ltr';
+		expect(getRtl()).toBe(false);
+
+		document.documentElement.setAttribute('dir', 'ltr');
+		expect(getRtl()).toBe(false);
+	});
+});

--- a/packages/create-styles/src/create-compiler/__tests__/rtl.test.js
+++ b/packages/create-styles/src/create-compiler/__tests__/rtl.test.js
@@ -16,4 +16,12 @@ describe('getRtl', () => {
 		document.documentElement.setAttribute('dir', 'ltr');
 		expect(getRtl()).toBe(false);
 	});
+
+	test('should return true when document is rtl', () => {
+		document.dir = 'rtl';
+		expect(getRtl()).toBe(true);
+
+		document.documentElement.setAttribute('dir', 'rtl');
+		expect(getRtl()).toBe(true);
+	});
 });

--- a/packages/create-styles/src/create-compiler/plugins/rtl.js
+++ b/packages/create-styles/src/create-compiler/plugins/rtl.js
@@ -6,9 +6,11 @@ import rtlcss from 'rtlcss';
 
 import { STYLIS_CONTEXTS } from './utils';
 
-let isRtl = false;
-if (typeof window !== 'undefined') {
-	isRtl = window?.document?.documentElement?.dir === 'rtl';
+export function getRtl() {
+	if (typeof window !== 'undefined') {
+		return window?.document?.dir === 'rtl';
+	}
+	return false;
 }
 
 // We need to apply cssjanus as early as possible to capture the noflip directives if used
@@ -32,7 +34,7 @@ export const STYLIS_PROPERTY_CONTEXT = STYLIS_CONTEXTS.PREPARATION;
 function stylisRTLPlugin(context, content) {
 	if (context === STYLIS_PROPERTY_CONTEXT) {
 		// pass four undefineds to let TS know which overload we're using
-		return isRtl
+		return getRtl()
 			? rtlcss.process(content, undefined, undefined, undefined)
 			: undefined;
 	}


### PR DESCRIPTION
Using `document.dir` instead of `document.getAttribute('dir')` for `rtl` checking
https://developer.mozilla.org/en-US/docs/Web/API/Document/dir

I didn't know about this 😍 
It's also much faster (tested with https://jsbench.me/)

Resolves: https://github.com/ItsJonQ/g2/issues/270