### PR TITLE
Do not use ForwardRefRenderFuction

### DIFF
--- a/packages/context/src/context-connect.js
+++ b/packages/context/src/context-connect.js
@@ -16,7 +16,7 @@ import { CONNECT_STATIC_NAMESPACE } from './constants';
  * component wrappers.
  *
  * @template {import('@wp-g2/create-styles').ViewOwnProps<{}, any>} P
- * @param {import('react').ForwardRefRenderFunction<import('@wp-g2/create-styles').ElementTypeFromViewOwnProps<P>, P>} Component The component to register into the Context system.
+ * @param {(props: P, ref: import('react').Ref<any>) => JSX.Element} Component The component to register into the Context system.
  * @param {Array<string>|string} namespace The namespace to register the component under.
  * @param {object} options
  * @param {boolean} [options.memo=true]


### PR DESCRIPTION
This simplifies the type and removes duplication of the `children` type which is problematic for elements like `hr` and `img` which do NOT have children.

Eventually we'll remove `children` from `ViewOwnProps` but that's a project for another day and will require a big refactor in the already ported component's types to explicitly annotate `children`. We should probably do this sooner than later though (probably this should be the first thing we do once these libraries exist in Gutenberg).