### PR TITLE
Update react-colorful

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -27,7 +27,7 @@
     "history": "^4.9.0",
     "lodash": "^4.17.19",
     "path-to-regexp": "^1.7.0",
-    "react-colorful": "4.4.4",
+    "react-colorful": "5.0.1",
     "react-textarea-autosize": "^8.2.0",
     "react-use-gesture": "^9.0.0",
     "reakit": "^1.3.4"

--- a/packages/components/src/ColorPicker/ColorPicker.js
+++ b/packages/components/src/ColorPicker/ColorPicker.js
@@ -40,7 +40,7 @@ function ColorPicker(props, forwardedRef) {
 					className={classes}
 					ref={forwardedRef}
 				>
-					<ColorPickerElement width={width} />
+					<ColorPickerElement />
 				</ColorPickerView>
 				<VStack alignment="top" isExpanded={false}>
 					<ColorPickerSelect />

--- a/packages/components/src/ColorPicker/ColorPicker.styles.js
+++ b/packages/components/src/ColorPicker/ColorPicker.styles.js
@@ -1,130 +1,33 @@
 import { css, styled, ui } from '@wp-g2/styles';
 
-const alphaPatternSvg = `url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill-opacity=".05"><path d="M8 0h8v8H8zM0 8h8v8H0z"/></svg>')`;
-
-/**
- * Styles absorbed from:
- * https://github.com/omgovich/react-colorful/blob/master/src/css/styles.css
- */
 export const ColorPickerView = styled.div`
 	.react-colorful {
-		cursor: default;
-		display: flex;
-		flex-direction: column;
-		height: 100%;
-		position: relative;
-		min-height: 128px;
-		user-select: none;
 		width: 100%;
-	}
-
-	.react-colorful__saturation {
-		position: relative;
-		flex-grow: 1;
-		border-bottom: 8px solid #000;
-		border-radius: 0;
-		background-image: linear-gradient(to top, #000, rgba(0, 0, 0, 0)),
-			linear-gradient(to right, #fff, rgba(255, 255, 255, 0));
-	}
-
-	.react-colorful__pointer-fill,
-	.react-colorful__alpha-gradient {
-		content: '';
-		position: absolute;
-		left: 0;
-		top: 0;
-		right: 0;
-		bottom: 0;
-		pointer-events: none;
-		border-radius: inherit;
-	}
-
-	/* Improve elements rendering on light backgrounds */
-	.react-colorful__alpha-gradient,
-	.react-colorful__saturation {
-		box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.05);
+		height: 100%;
+		min-height: 128px;
 	}
 
 	.react-colorful__hue,
 	.react-colorful__alpha {
-		position: relative;
 		height: 16px;
-	}
-
-	.react-colorful__hue {
-		border-radius: 3px 3px 0 0;
-		background: linear-gradient(
-			to right,
-			#f00 0%,
-			#ff0 17%,
-			#0f0 33%,
-			#0ff 50%,
-			#00f 67%,
-			#f0f 83%,
-			#f00 100%
-		);
 	}
 
 	.react-colorful__last-control {
 		border-radius: 0 0 3px 3px;
 	}
 
-	.react-colorful__interactive {
-		position: absolute;
-		left: 0;
-		top: 0;
-		right: 0;
-		bottom: 0;
-		border-radius: inherit;
-		outline: none;
-		/* Don't trigger the default scrolling behavior when the event is originating from this element */
-		touch-action: none;
-	}
-
 	.react-colorful__pointer {
-		position: absolute;
-		z-index: 1;
-		box-sizing: border-box;
 		width: 20px;
 		height: 20px;
-		transform: translate(-50%, -50%);
-		background-color: #fff;
-		border: 2px solid #fff;
-		border-radius: 50%;
-		box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-	}
-
-	.react-colorful__interactive:focus .react-colorful__pointer {
-		transform: translate(-50%, -50%) scale(1.1);
-	}
-
-	/* Chessboard-like pattern for alpha related elements */
-	.react-colorful__alpha,
-	.react-colorful__alpha-pointer {
-		background-color: #fff;
-		background-image: ${alphaPatternSvg};
-	}
-
-	/* Display the saturation pointer over the hue one */
-	.react-colorful__saturation-pointer {
-		z-index: 3;
-	}
-
-	/* Display the hue pointer over the alpha one */
-	.react-colorful__hue-pointer {
-		z-index: 2;
 	}
 
 	.react-colorful__hue {
-		order: 0;
+		order: -1;
+		border-radius: 3px 3px 0 0;
 	}
 
 	.react-colorful__saturation {
-		order: 1;
-	}
-
-	.react-colorful__alpha {
-		order: 2;
+		border-radius: 0;
 	}
 `;
 

--- a/packages/components/src/ColorPicker/ColorPickerElement.js
+++ b/packages/components/src/ColorPicker/ColorPickerElement.js
@@ -3,7 +3,7 @@ import { RgbaColorPicker } from 'react-colorful';
 
 import { useColorPickerContext } from './ColorPicker.Context';
 
-export const ColorPickerElement = React.memo(({ width }) => {
+export const ColorPickerElement = React.memo(() => {
 	const { colorRgb, onChange } = useColorPickerContext();
 
 	/**
@@ -14,11 +14,7 @@ export const ColorPickerElement = React.memo(({ width }) => {
 
 	return (
 		<div onMouseDown={handleOnFocusInteractiveControl}>
-			<RgbaColorPicker
-				color={colorRgb}
-				onChange={onChange}
-				width={width}
-			/>
+			<RgbaColorPicker color={colorRgb} onChange={onChange} />
 		</div>
 	);
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -20530,10 +20530,10 @@ react-color@^2.17.0, react-color@^2.17.3:
     reactcss "^1.2.0"
     tinycolor2 "^1.4.1"
 
-react-colorful@4.4.4:
-  version "4.4.4"
-  resolved "https://registry.yarnpkg.com/react-colorful/-/react-colorful-4.4.4.tgz#38e7c5b7075bbf63d3cce22d8c61a439a58b7561"
-  integrity sha512-01V2/6rr6sa1vaZntWZJXZxnU7ew02NG2rqq0eoVp4d3gFU5Ug9lDzNMbr+8ns0byXsJbBR8LbwQTlAjz6x7Kg==
+react-colorful@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/react-colorful/-/react-colorful-5.0.1.tgz#50dcd10cd94bc0b2257492ca8785c53b07805faf"
+  integrity sha512-I/ctDkUZVCIKvIqBwqQWphPxDUJv8q1omKzQ3XJ6H3PhrxF/1t9olNVcTKBJSTKDACZJbyJ0cEAUi3rvAZWdSA==
 
 react-dev-utils@^10.0.0:
   version "10.2.1"


### PR DESCRIPTION
- Updated react-colorful from 4.4.4 to 5.0.1 
- v5 has built-in styles (doesn't require CSS-loader) so it's possible to remove all of the styles copied from the picker's repo