### PR TITLE
Add preliminary documentation to create-styles

### DIFF
--- a/packages/create-styles/src/create-compiler/README.md
+++ b/packages/create-styles/src/create-compiler/README.md
@@ -1,0 +1,68 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+-   [create-compiler](#create-compiler)
+    -   [Breakpoint values](#breakpoint-values)
+    -   [Plugins](#plugins)
+    -   [Custom iframe support](#custom-iframe-support)
+    -   [Interplated Components](#interplated-components)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+# create-compiler
+
+This module creates the Emotion instance that backs the style system. It integrates plugins and creates the core `css` function that wraps Emotion's `css` function adding support for breakpoint values on each property.
+
+## Breakpoint values
+
+Breakpoint values are supported by passing an array of values to a CSS property. For example:
+
+```js
+css({
+	width: [300, 500, 700],
+});
+```
+
+This will dynamically respond to breakpoints and render the appropriate width for each `min-width`. The breakpoints are documented in the code in [`utils.js`](./utils.js).
+
+## Plugins
+
+`createCompiler` supports passing certain parameters to plugins. Plugin initialization should be contained to [`plugins/index.js`](./plugins/index.js).
+
+The individual plugins are documented in [`plugins/README.md`](./plugins/README.md).
+
+## Custom iframe support
+
+Emotion by default does not support iframe styling. The G2 solves this by implementing a custom `sheet.insert` that exposes a `sheet.insert` event which can be listened to by style providers to receive styles from outside of the current iframe.
+
+(Q, please fill in some more of the implementation details to this).
+
+## Interplated Components
+
+`css` also supports passing style system-connected components as selectors in the same style as `styled-components`. It does this _without any Babel transformations_. Interpolated components are transformed to a special interpolated class name by the `css` function. Components are given an interpolation class name (prefixed by `ic-`) by either the `contextConnect` hook or by `styled` itself. `css` then detects when a component has been passed in and transorms it into a CSS selector.
+
+For example:
+
+```js
+const Text = styled.div`
+	color: red;
+`;
+
+const greenText = css`
+	${Text} {
+		color: green;
+	}
+`;
+```
+
+Now any child `Text` of a component that applies the `greenText` generated class name will be targeted with the `color: green` styles.
+
+Psueudo selectors against the interpolated component are possible as well:
+
+```js
+const blueText = css`
+	${Text}:first-child {
+		color: blue;
+	}
+`;
+```

--- a/packages/create-styles/src/create-compiler/plugins/README.md
+++ b/packages/create-styles/src/create-compiler/plugins/README.md
@@ -1,0 +1,40 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+-   [plugins](#plugins)
+    -   [Extra Specificity](#extra-specificity)
+    -   [CSS Variable Fallback](#css-variable-fallback)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+# plugins
+
+This foler contains all the applied plugins in G2.
+
+## Extra Specificity
+
+This plugin automatically compounds selector specificity by simply repeating the selector x number of times. For example, if a specificity of 3 is passed in, the plugin will transform:
+
+```css
+.css-abc123 {
+	color: red;
+}
+```
+
+into:
+
+```css
+.css-abc123.css-abc123.css-abc123 {
+	color: red;
+}
+```
+
+This is meant to prevent "hacks" from being applied to the component system via regular css selection (or rather to make it difficult/annoying to do so), forcing consumers to use the style system itself, for example, the `css` prop and theme variables, to apply custom styles.
+
+It is currently set to a specificity of 1 to disable it. This may be reversed in the future. If it isn't reversed in the future, at some point we shoiuld just remove it.
+
+## CSS Variable Fallback
+
+The [`css-variables.js` ](./css-variables.js) plugin automatically generates fallback variables to support browsers that lack CSS variable support.
+
+Given WordPress core is dropping IE11 support,we might be able to drop this plugin altogether.

--- a/packages/create-styles/src/create-style-system/README.md
+++ b/packages/create-styles/src/create-style-system/README.md
@@ -1,0 +1,110 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+-   [create-style-system](#create-style-system)
+    -   [styled](#styled)
+    -   [Polymorphic Component](#polymorphic-component)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+# create-style-system
+
+This module creates the `styled` utility as well as the overall style system.
+
+## styled
+
+`styled` works just as Emotion's and `styled-components`'s `styled` function objects. It is able to accept a component as an argument to style as well as is a collection of "core elements" that can be used to create styled elements on the fly.
+
+For example:
+
+```js
+const Text = styled.span`
+	color: blue;
+`;
+```
+
+`Text` is a React component that will render a `span` with the custom styles applied.
+
+`styled` can also be used as a function to apply custom styles to existing components:
+
+```jsx
+const Component = ({ className }) => {
+	return <div className={className}>My Favorite Component</div>;
+};
+
+const StyledComponent = styled(Component)`
+	color: green;
+`;
+```
+
+For a component to be able to be passed to `styled`, the only requirement is that it forward the `className` prop.
+
+Ultimately `styled` is just an interface for `css` that automatically applies the generated class name from the CSS to a given component, whether that is one of the core elements or a passed in component. That is why passed in components must forward the `className` prop.
+
+`styled` also supports component interpolation. See [`css`'s documentation here](../create-compiler/README.md) for more information on how it works. A breif example is here:
+
+```js
+const Text = styled.span`
+	color: red;
+`;
+
+const Container = styled.div`
+	display: flex;
+
+	${Text} {
+		color: blue;
+	}
+`;
+```
+
+Now any child component `Text` of `Container` will be targeted with the `color: blue` style, while `Text` itself will continue to render the `color: red` style.
+
+## Polymorphic Component
+
+This module also exposes the concept of the Polymorphic Component. This concept is not new to G2 but G2 uses it extensively and it is one of the more powerful aspects of G2's style system.
+
+Poylmorphic components are able to accept an `as` prop that will accept any React component or JSX Element name. For example:
+
+```jsx
+<View as="span" />
+```
+
+Will render everything `View` renders but as a `span`.
+
+This is even more powerful when combining elements:
+
+```jsx
+<VStack as="form">
+	<HStack as={Button} variant="primary">
+		<View as="span" css={{ color: 'red' }}>
+			Click me!
+		</View>
+	</HStack>
+</VStack>
+```
+
+As you can see, the component polymorphism allows you to powerfully compose the component system with itself and with other component systems. Even passing `as={ ReakitComponent }` for example will work, enabling powerful accessibility patterns while still maintaining the power of the style system on the core `View` component.
+
+Component polymorphism is documented via the `PolymorphicComponent` type in `polymorphic-component.ts`.
+
+The same module also exposes a `ViewOwnProps` type which gives the `css` and `as` props to a regular `Props` interface:
+
+```tsx
+interface Props {
+	foo: string;
+}
+
+function MyButton(props: ViewOwnProps<Props, 'button'>) {
+	return <View as="button" {...props} />;
+}
+```
+
+The second parameter to `ViewOwnProps` should indicate the _default_ `as` value for the component. That is, if the component renders a `button` as the example above does, it should be `button`. This will give the `props` type all of the appropriate `HTMLAttributes` for the given intrinsic element. For example, our `MyButton` component above is able to accept a strongly typed `onClick` for a `MouseEvent<HTMLButtonElement>`. Likewise, this will automagically change if `as` is passed as a different value:
+
+```jsx
+<MyButton as="a" href="https://wordpress.org">
+	Code is Poetry
+</MyButton>
+```
+
+`href` will be strongly typed to the `HTMLAnchorAttributes` prop.


### PR DESCRIPTION
Missing from this PR:

- [ ] ThemeProvider
- [ ] CSS Custom Properties (Can we delete this, it was for IE11 support right?)
- [ ] Hooks