### PR TITLE
Add `type="button"` to components using `as="button"` implicitly

### DIFF
--- a/packages/components/src/TextInput/TextInputSteppers.js
+++ b/packages/components/src/TextInput/TextInputSteppers.js
@@ -136,6 +136,7 @@ const _UpDownArrows = ({
 				onMouseDown={handleOnMouseDownIncrement}
 				onMouseLeave={handleOnClearTimers}
 				onMouseUp={handleOnClearTimers}
+				type="button"
 				{...ui.$('TextInputStepperUp')}
 				height={`calc(100% - 4px)`}
 				icon={plus}
@@ -150,6 +151,7 @@ const _UpDownArrows = ({
 				onMouseDown={handleOnMouseDownDecrement}
 				onMouseLeave={handleOnClearTimers}
 				onMouseUp={handleOnClearTimers}
+				type="button"
 				{...ui.$('TextInputStepperDown')}
 				height={`calc(100% - 4px)`}
 				icon={minus}

--- a/packages/components/src/__tests__/__snapshots__/Components.test.js.snap
+++ b/packages/components/src/__tests__/__snapshots__/Components.test.js.snap
@@ -28379,6 +28379,7 @@ exports[`props should render SelectDropdown 1`] = `
       data-g2-c16t="true"
       data-g2-component="SelectDropdownReference"
       id="SelectDropdown"
+      type="button"
       value=""
     >
       <span
@@ -28856,6 +28857,7 @@ exports[`props should render SelectDropdown with css prop 1`] = `
       data-g2-c16t="true"
       data-g2-component="SelectDropdownReference"
       id="SelectDropdown"
+      type="button"
       value=""
     >
       <span
@@ -29335,6 +29337,7 @@ exports[`props should render SelectDropdown with css prop 2`] = `
       data-g2-c16t="true"
       data-g2-component="SelectDropdownReference"
       id="SelectDropdown"
+      type="button"
       value=""
     >
       <span

--- a/packages/components/src/select-dropdown/__tests__/__snapshots__/index.js.snap
+++ b/packages/components/src/select-dropdown/__tests__/__snapshots__/index.js.snap
@@ -426,6 +426,7 @@ exports[`props should render correctly 1`] = `
       class="ic-192yz5d emotion-2"
       data-g2-c16t="true"
       data-g2-component="SelectDropdownReference"
+      type="button"
       value=""
     >
       <span

--- a/packages/components/src/select-dropdown/select-dropdown.js
+++ b/packages/components/src/select-dropdown/select-dropdown.js
@@ -31,7 +31,7 @@ function SelectDropdown(props, forwardedRef) {
 	return (
 		<View {...otherProps} ref={forwardedRef}>
 			{resizer}
-			<Select as="button" {...referenceProps}>
+			<Select as="button" type="button" {...referenceProps}>
 				<Truncate>{referenceProps.children}</Truncate>
 			</Select>
 			<SelectDropdownLabel {...labelProps} />


### PR DESCRIPTION
Similar to #288, this PR adds `type="button"` to those components implicitly using `as="button"`. So that they won't be rendered as a submit button when placed inside a `<form>` element.